### PR TITLE
C965 beanstalk

### DIFF
--- a/app/all/providers.go
+++ b/app/all/providers.go
@@ -1,0 +1,24 @@
+package all
+
+import (
+	"github.com/nullstone-io/deployment-sdk/app"
+	"github.com/nullstone-io/deployment-sdk/app/container/aws-ecs-ec2"
+	"github.com/nullstone-io/deployment-sdk/app/container/aws-ecs-fargate"
+	"github.com/nullstone-io/deployment-sdk/app/server/aws-beanstalk"
+	"github.com/nullstone-io/deployment-sdk/app/server/aws-ec2"
+	"github.com/nullstone-io/deployment-sdk/app/serverless/aws-lambda-container"
+	"github.com/nullstone-io/deployment-sdk/app/serverless/aws-lambda-zip"
+	"github.com/nullstone-io/deployment-sdk/app/static-site/aws-s3"
+)
+
+var (
+	Providers = app.Providers{
+		aws_ecs_fargate.ModuleContractName:      aws_ecs_fargate.Provider,
+		aws_ecs_ec2.ModuleContractName:          aws_ecs_ec2.Provider,
+		aws_s3.ModuleContractName:               aws_s3.Provider,
+		aws_lambda_zip.ModuleContractName:       aws_lambda_zip.Provider,
+		aws_lambda_container.ModuleContractName: aws_lambda_container.Provider,
+		aws_ec2.ModuleContractName:              aws_ec2.Provider,
+		aws_beanstalk.ModuleContractName:        aws_beanstalk.Provider,
+	}
+)

--- a/app/server/aws-beanstalk/provider.go
+++ b/app/server/aws-beanstalk/provider.go
@@ -17,5 +17,5 @@ var ModuleContractName = types.ModuleContractName{
 var Provider = app.Provider{
 	NewPusher:             beanstalk.NewPusher,
 	NewDeployer:           beanstalk.NewDeployer,
-	NewDeployStatusGetter: nil,
+	NewDeployStatusGetter: beanstalk.NewDeployStatusGetter,
 }

--- a/app/server/aws-beanstalk/provider.go
+++ b/app/server/aws-beanstalk/provider.go
@@ -1,0 +1,21 @@
+package aws_beanstalk
+
+import (
+	"github.com/nullstone-io/deployment-sdk/app"
+	"github.com/nullstone-io/deployment-sdk/aws/beanstalk"
+	"gopkg.in/nullstone-io/go-api-client.v0/types"
+)
+
+var ModuleContractName = types.ModuleContractName{
+	Category:    string(types.CategoryApp),
+	Subcategory: string(types.SubcategoryAppServer),
+	Provider:    "aws",
+	Platform:    "ec2",
+	Subplatform: "beanstalk",
+}
+
+var Provider = app.Provider{
+	NewPusher:             beanstalk.NewPusher,
+	NewDeployer:           beanstalk.NewDeployer,
+	NewDeployStatusGetter: nil,
+}

--- a/app/serverless/aws-lambda-zip/provider.go
+++ b/app/serverless/aws-lambda-zip/provider.go
@@ -3,6 +3,7 @@ package aws_lambda_zip
 import (
 	"github.com/nullstone-io/deployment-sdk/app"
 	"github.com/nullstone-io/deployment-sdk/aws/lambda-zip"
+	"github.com/nullstone-io/deployment-sdk/aws/s3"
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
 )
 
@@ -15,7 +16,7 @@ var ModuleContractName = types.ModuleContractName{
 }
 
 var Provider = app.Provider{
-	NewPusher:             lambda_zip.NewPusher,
+	NewPusher:             s3.NewZipPusher,
 	NewDeployer:           lambda_zip.NewDeployer,
 	NewDeployStatusGetter: nil,
 }

--- a/app/static-site/aws-s3/provider.go
+++ b/app/static-site/aws-s3/provider.go
@@ -16,7 +16,7 @@ var ModuleContractName = types.ModuleContractName{
 }
 
 var Provider = app.Provider{
-	NewPusher:             s3.NewPusher,
+	NewPusher:             s3.NewDirPusher,
 	NewDeployer:           cdn.NewDeployer,
 	NewDeployStatusGetter: cdn.NewDeployStatusGetter,
 }

--- a/aws/beanstalk/create_app_version.go
+++ b/aws/beanstalk/create_app_version.go
@@ -1,0 +1,30 @@
+package beanstalk
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk"
+	ebtypes "github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk/types"
+	"github.com/nullstone-io/deployment-sdk/aws"
+)
+
+func CreateAppVersion(ctx context.Context, infra Outputs, version string) (string, error) {
+	bclient := elasticbeanstalk.NewFromConfig(nsaws.NewConfig(infra.Deployer, infra.Region))
+	out, err := bclient.CreateApplicationVersion(ctx, &elasticbeanstalk.CreateApplicationVersionInput{
+		ApplicationName:       aws.String(infra.BeanstalkName),
+		VersionLabel:          aws.String(version),
+		AutoCreateApplication: aws.Bool(false),
+		Process:               aws.Bool(true),
+		SourceBundle: &ebtypes.S3Location{
+			S3Bucket: aws.String(infra.ArtifactsBucketName),
+			S3Key:    aws.String(infra.ArtifactsKey(version)),
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	if out.ApplicationVersion == nil || out.ApplicationVersion.ApplicationVersionArn == nil {
+		return "", nil
+	}
+	return *out.ApplicationVersion.ApplicationVersionArn, nil
+}

--- a/aws/beanstalk/deploy_status_getter.go
+++ b/aws/beanstalk/deploy_status_getter.go
@@ -1,0 +1,61 @@
+package beanstalk
+
+import (
+	"context"
+	ebtypes "github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk/types"
+	"github.com/nullstone-io/deployment-sdk/app"
+	"github.com/nullstone-io/deployment-sdk/logging"
+	"github.com/nullstone-io/deployment-sdk/outputs"
+	"gopkg.in/nullstone-io/go-api-client.v0"
+)
+
+func NewDeployStatusGetter(osWriters logging.OsWriters, nsConfig api.Config, appDetails app.Details) (app.DeployStatusGetter, error) {
+	outs, err := outputs.Retrieve[Outputs](nsConfig, appDetails.Workspace)
+	if err != nil {
+		return nil, err
+	}
+
+	return DeployStatusGetter{
+		OsWriters: osWriters,
+		Details:   appDetails,
+		Infra:     outs,
+	}, nil
+}
+
+type DeployStatusGetter struct {
+	OsWriters logging.OsWriters
+	Details   app.Details
+	Infra     Outputs
+}
+
+func (d DeployStatusGetter) GetDeployStatus(ctx context.Context, reference string) (app.RolloutStatus, error) {
+	if reference == "" {
+		return app.RolloutStatusUnknown, nil
+	}
+
+	env, err := GetEnvironmentStatus(ctx, d.Infra, reference)
+	if err != nil {
+		return app.RolloutStatusUnknown, err
+	}
+	rolloutStatus := d.mapRolloutStatus(env)
+	// TODO: Is there additional information to log?
+	// TODO: Check env.Health for LB health checks?
+	return rolloutStatus, nil
+}
+
+func (d DeployStatusGetter) mapRolloutStatus(env *ebtypes.EnvironmentDescription) app.RolloutStatus {
+	switch env.Status {
+	case "Launching":
+		return app.RolloutStatusInProgress
+	case "Updating":
+		return app.RolloutStatusInProgress
+	case "Ready":
+		return app.RolloutStatusComplete
+	case "Terminating":
+		return app.RolloutStatusFailed
+	case "Terminated":
+		return app.RolloutStatusFailed
+	default:
+		return app.RolloutStatusUnknown
+	}
+}

--- a/aws/beanstalk/deployer.go
+++ b/aws/beanstalk/deployer.go
@@ -17,7 +17,6 @@ func NewDeployer(osWriters logging.OsWriters, nsConfig api.Config, appDetails ap
 
 	return Deployer{
 		OsWriters: osWriters,
-		NsConfig:  nsConfig,
 		Details:   appDetails,
 		Infra:     outs,
 	}, nil
@@ -25,7 +24,6 @@ func NewDeployer(osWriters logging.OsWriters, nsConfig api.Config, appDetails ap
 
 type Deployer struct {
 	OsWriters logging.OsWriters
-	NsConfig  api.Config
 	Details   app.Details
 	Infra     Outputs
 }
@@ -43,5 +41,5 @@ func (d Deployer) Deploy(ctx context.Context, version string) (string, error) {
 	}
 
 	fmt.Fprintf(stdout, "Deployed app %q\n", d.Details.App.Name)
-	return "", nil
+	return version, nil
 }

--- a/aws/beanstalk/deployer.go
+++ b/aws/beanstalk/deployer.go
@@ -1,0 +1,47 @@
+package beanstalk
+
+import (
+	"context"
+	"fmt"
+	"github.com/nullstone-io/deployment-sdk/app"
+	"github.com/nullstone-io/deployment-sdk/logging"
+	"github.com/nullstone-io/deployment-sdk/outputs"
+	"gopkg.in/nullstone-io/go-api-client.v0"
+)
+
+func NewDeployer(osWriters logging.OsWriters, nsConfig api.Config, appDetails app.Details) (app.Deployer, error) {
+	outs, err := outputs.Retrieve[Outputs](nsConfig, appDetails.Workspace)
+	if err != nil {
+		return nil, err
+	}
+
+	return Deployer{
+		OsWriters: osWriters,
+		NsConfig:  nsConfig,
+		Details:   appDetails,
+		Infra:     outs,
+	}, nil
+}
+
+type Deployer struct {
+	OsWriters logging.OsWriters
+	NsConfig  api.Config
+	Details   app.Details
+	Infra     Outputs
+}
+
+func (d Deployer) Deploy(ctx context.Context, version string) (string, error) {
+	stdout, _ := d.OsWriters.Stdout(), d.OsWriters.Stderr()
+	fmt.Fprintf(stdout, "Deploying app %q\n", d.Details.App.Name)
+	if version == "" {
+		return "", fmt.Errorf("--version is required to deploy app")
+	}
+
+	fmt.Fprintf(stdout, "Updating application environment %q...\n", version)
+	if err := UpdateEnvironment(ctx, d.Infra, version); err != nil {
+		return "", fmt.Errorf("error updating application environment: %w", err)
+	}
+
+	fmt.Fprintf(stdout, "Deployed app %q\n", d.Details.App.Name)
+	return "", nil
+}

--- a/aws/beanstalk/get_environment_status.go
+++ b/aws/beanstalk/get_environment_status.go
@@ -1,0 +1,26 @@
+package beanstalk
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk"
+	"github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk/types"
+	"github.com/nullstone-io/deployment-sdk/aws"
+)
+
+func GetEnvironmentStatus(ctx context.Context, infra Outputs, reference string) (*types.EnvironmentDescription, error) {
+	bclient := elasticbeanstalk.NewFromConfig(nsaws.NewConfig(infra.Deployer, infra.Region))
+	out, err := bclient.DescribeEnvironments(ctx, &elasticbeanstalk.DescribeEnvironmentsInput{
+		ApplicationName: aws.String(infra.BeanstalkName),
+		EnvironmentIds:  []string{infra.EnvironmentId},
+		VersionLabel:    aws.String(reference),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if out == nil || out.Environments == nil || len(out.Environments) < 1 {
+		return nil, nil
+	}
+	e := out.Environments[0]
+	return &e, nil
+}

--- a/aws/beanstalk/outputs.go
+++ b/aws/beanstalk/outputs.go
@@ -1,0 +1,27 @@
+package beanstalk
+
+import (
+	"github.com/nullstone-io/deployment-sdk/aws"
+	"strings"
+)
+
+const (
+	KeyTemplateAppVersion = "{{app-version}}"
+)
+
+type Outputs struct {
+	Region               string     `ns:"region"`
+	Deployer             nsaws.User `ns:"deployer"`
+	BeanstalkName        string     `ns:"beanstalk_name"`
+	EnvironmentId        string     `ns:"environment_id"`
+	ArtifactsBucketName  string     `ns:"artifacts_bucket_name"`
+	ArtifactsKeyTemplate string     `ns:"artifacts_key_template"`
+}
+
+func (o Outputs) ArtifactsKey(appVersion string) string {
+	tmpl := o.ArtifactsKeyTemplate
+	if tmpl == "" {
+		tmpl = "{{app-version}}"
+	}
+	return strings.Replace(tmpl, KeyTemplateAppVersion, appVersion, -1)
+}

--- a/aws/beanstalk/pusher.go
+++ b/aws/beanstalk/pusher.go
@@ -1,0 +1,54 @@
+package beanstalk
+
+import (
+	"context"
+	"fmt"
+	"github.com/nullstone-io/deployment-sdk/app"
+	"github.com/nullstone-io/deployment-sdk/aws/s3"
+	"github.com/nullstone-io/deployment-sdk/logging"
+	"github.com/nullstone-io/deployment-sdk/outputs"
+	"gopkg.in/nullstone-io/go-api-client.v0"
+)
+
+func NewPusher(osWriters logging.OsWriters, nsConfig api.Config, appDetails app.Details) (app.Pusher, error) {
+	outs, err := outputs.Retrieve[Outputs](nsConfig, appDetails.Workspace)
+	if err != nil {
+		return nil, err
+	}
+	zipPusher := &s3.ZipPusher{
+		OsWriters: osWriters,
+		Infra: s3.Outputs{
+			Region:               outs.Region,
+			Deployer:             outs.Deployer,
+			ArtifactsBucketName:  outs.ArtifactsBucketName,
+			ArtifactsKeyTemplate: outs.ArtifactsKeyTemplate,
+		},
+	}
+
+	return &Pusher{
+		zipPusher: zipPusher,
+		OsWriters: osWriters,
+		Infra:     outs,
+	}, nil
+}
+
+type Pusher struct {
+	zipPusher *s3.ZipPusher
+	OsWriters logging.OsWriters
+	Infra     Outputs
+}
+
+func (p Pusher) Push(ctx context.Context, source, version string) error {
+	if err := p.zipPusher.Push(ctx, source, version); err != nil {
+		return err
+	}
+
+	stdout, _ := p.OsWriters.Stdout(), p.OsWriters.Stderr()
+	fmt.Fprintf(stdout, "Creating application version %q...\n", version)
+	if _, err := CreateAppVersion(ctx, p.Infra, version); err != nil {
+		return fmt.Errorf("error creating application version: %w", err)
+	}
+	fmt.Fprintf(stdout, "Created application version %q\n", version)
+
+	return nil
+}

--- a/aws/beanstalk/update_environment.go
+++ b/aws/beanstalk/update_environment.go
@@ -1,0 +1,18 @@
+package beanstalk
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk"
+	"github.com/nullstone-io/deployment-sdk/aws"
+)
+
+func UpdateEnvironment(ctx context.Context, infra Outputs, version string) error {
+	bclient := elasticbeanstalk.NewFromConfig(nsaws.NewConfig(infra.Deployer, infra.Region))
+	_, err := bclient.UpdateEnvironment(ctx, &elasticbeanstalk.UpdateEnvironmentInput{
+		ApplicationName: aws.String(infra.BeanstalkName),
+		EnvironmentId:   aws.String(infra.EnvironmentId),
+		VersionLabel:    aws.String(version),
+	})
+	return err
+}

--- a/aws/cdn/deploy_status_getter.go
+++ b/aws/cdn/deploy_status_getter.go
@@ -18,7 +18,6 @@ func NewDeployStatusGetter(osWriters logging.OsWriters, nsConfig api.Config, app
 
 	return DeployStatusGetter{
 		OsWriters: osWriters,
-		NsConfig:  nsConfig,
 		Details:   appDetails,
 		Infra:     outs,
 	}, nil
@@ -26,7 +25,6 @@ func NewDeployStatusGetter(osWriters logging.OsWriters, nsConfig api.Config, app
 
 type DeployStatusGetter struct {
 	OsWriters logging.OsWriters
-	NsConfig  api.Config
 	Details   app.Details
 	Infra     Outputs
 }

--- a/aws/cdn/deployer.go
+++ b/aws/cdn/deployer.go
@@ -17,7 +17,6 @@ func NewDeployer(osWriters logging.OsWriters, nsConfig api.Config, appDetails ap
 
 	return Deployer{
 		OsWriters: osWriters,
-		NsConfig:  nsConfig,
 		Details:   appDetails,
 		Infra:     outs,
 	}, nil
@@ -25,7 +24,6 @@ func NewDeployer(osWriters logging.OsWriters, nsConfig api.Config, appDetails ap
 
 type Deployer struct {
 	OsWriters logging.OsWriters
-	NsConfig  api.Config
 	Details   app.Details
 	Infra     Outputs
 }

--- a/aws/ecr/pusher.go
+++ b/aws/ecr/pusher.go
@@ -28,14 +28,12 @@ func NewPusher(osWriters logging.OsWriters, nsConfig api.Config, appDetails app.
 	}
 	return &Pusher{
 		OsWriters: osWriters,
-		NsConfig:  nsConfig,
 		Infra:     outs,
 	}, nil
 }
 
 type Pusher struct {
 	OsWriters logging.OsWriters
-	NsConfig  api.Config
 	Infra     Outputs
 }
 

--- a/aws/ecs/deploy_status_getter.go
+++ b/aws/ecs/deploy_status_getter.go
@@ -19,7 +19,6 @@ func NewDeployStatusGetter(osWriters logging.OsWriters, nsConfig api.Config, app
 
 	return DeployStatusGetter{
 		OsWriters: osWriters,
-		NsConfig:  nsConfig,
 		Details:   appDetails,
 		Infra:     outs,
 	}, nil
@@ -27,7 +26,6 @@ func NewDeployStatusGetter(osWriters logging.OsWriters, nsConfig api.Config, app
 
 type DeployStatusGetter struct {
 	OsWriters logging.OsWriters
-	NsConfig  api.Config
 	Details   app.Details
 	Infra     Outputs
 }

--- a/aws/ecs/deployer.go
+++ b/aws/ecs/deployer.go
@@ -17,7 +17,6 @@ func NewDeployer(osWriters logging.OsWriters, nsConfig api.Config, appDetails ap
 
 	return Deployer{
 		OsWriters: osWriters,
-		NsConfig:  nsConfig,
 		Details:   appDetails,
 		Infra:     outs,
 	}, nil
@@ -25,7 +24,6 @@ func NewDeployer(osWriters logging.OsWriters, nsConfig api.Config, appDetails ap
 
 type Deployer struct {
 	OsWriters logging.OsWriters
-	NsConfig  api.Config
 	Details   app.Details
 	Infra     Outputs
 }

--- a/aws/lambda-container/deployer.go
+++ b/aws/lambda-container/deployer.go
@@ -27,7 +27,6 @@ func NewDeployer(osWriters logging.OsWriters, nsConfig api.Config, appDetails ap
 
 	return Deployer{
 		OsWriters: osWriters,
-		NsConfig:  nsConfig,
 		Details:   appDetails,
 		Infra:     outs,
 	}, nil
@@ -35,7 +34,6 @@ func NewDeployer(osWriters logging.OsWriters, nsConfig api.Config, appDetails ap
 
 type Deployer struct {
 	OsWriters logging.OsWriters
-	NsConfig  api.Config
 	Details   app.Details
 	Infra     Outputs
 }

--- a/aws/lambda-zip/deployer.go
+++ b/aws/lambda-zip/deployer.go
@@ -17,7 +17,6 @@ func NewDeployer(osWriters logging.OsWriters, nsConfig api.Config, appDetails ap
 
 	return Deployer{
 		OsWriters: osWriters,
-		NsConfig:  nsConfig,
 		Details:   appDetails,
 		Infra:     outs,
 	}, nil
@@ -25,7 +24,6 @@ func NewDeployer(osWriters logging.OsWriters, nsConfig api.Config, appDetails ap
 
 type Deployer struct {
 	OsWriters logging.OsWriters
-	NsConfig  api.Config
 	Details   app.Details
 	Infra     Outputs
 }

--- a/aws/lambda-zip/outputs.go
+++ b/aws/lambda-zip/outputs.go
@@ -12,12 +12,15 @@ const (
 type Outputs struct {
 	Region               string     `ns:"region"`
 	Deployer             nsaws.User `ns:"deployer"`
-	LambdaArn            string     `ns:"lambda_arn"`
 	LambdaName           string     `ns:"lambda_name"`
 	ArtifactsBucketName  string     `ns:"artifacts_bucket_name"`
 	ArtifactsKeyTemplate string     `ns:"artifacts_key_template"`
 }
 
 func (o Outputs) ArtifactsKey(appVersion string) string {
-	return strings.Replace(o.ArtifactsKeyTemplate, KeyTemplateAppVersion, appVersion, -1)
+	tmpl := o.ArtifactsKeyTemplate
+	if tmpl == "" {
+		tmpl = "{{app-version}}"
+	}
+	return strings.Replace(tmpl, KeyTemplateAppVersion, appVersion, -1)
 }

--- a/aws/s3/dir_pusher.go
+++ b/aws/s3/dir_pusher.go
@@ -10,25 +10,25 @@ import (
 	"gopkg.in/nullstone-io/go-api-client.v0"
 )
 
-func NewPusher(osWriters logging.OsWriters, nsConfig api.Config, appDetails app.Details) (app.Pusher, error) {
+func NewDirPusher(osWriters logging.OsWriters, nsConfig api.Config, appDetails app.Details) (app.Pusher, error) {
 	outs, err := outputs.Retrieve[Outputs](nsConfig, appDetails.Workspace)
 	if err != nil {
 		return nil, err
 	}
-	return &Pusher{
+	return &DirPusher{
 		OsWriters: osWriters,
 		NsConfig:  nsConfig,
 		Infra:     outs,
 	}, nil
 }
 
-type Pusher struct {
+type DirPusher struct {
 	OsWriters logging.OsWriters
 	NsConfig  api.Config
 	Infra     Outputs
 }
 
-func (p Pusher) Push(ctx context.Context, source, version string) error {
+func (p DirPusher) Push(ctx context.Context, source, version string) error {
 	stdout, _ := p.OsWriters.Stdout(), p.OsWriters.Stderr()
 
 	if source == "" {
@@ -43,8 +43,8 @@ func (p Pusher) Push(ctx context.Context, source, version string) error {
 		return fmt.Errorf("error scanning source: %w", err)
 	}
 
-	fmt.Fprintf(stdout, "Uploading %s to s3 bucket %s...\n", source, p.Infra.BucketName)
-	if err := UploadArtifact(ctx, p.Infra, source, filepaths, version); err != nil {
+	fmt.Fprintf(stdout, "Uploading %s to s3 bucket %s...\n", source, p.Infra.ArtifactsBucketName)
+	if err := UploadDirArtifact(ctx, p.Infra, source, filepaths, version); err != nil {
 		return fmt.Errorf("error uploading artifact: %w", err)
 	}
 

--- a/aws/s3/outputs.go
+++ b/aws/s3/outputs.go
@@ -2,11 +2,24 @@ package s3
 
 import (
 	"github.com/nullstone-io/deployment-sdk/aws"
+	"strings"
+)
+
+const (
+	KeyTemplateAppVersion = "{{app-version}}"
 )
 
 type Outputs struct {
-	Region     string     `ns:"region"`
-	BucketName string     `ns:"bucket_name"`
-	BucketArn  string     `ns:"bucket_arn"`
-	Deployer   nsaws.User `ns:"deployer"`
+	Region               string     `ns:"region"`
+	Deployer             nsaws.User `ns:"deployer"`
+	ArtifactsBucketName  string     `ns:"artifacts_bucket_name"`
+	ArtifactsKeyTemplate string     `ns:"artifacts_key_template"`
+}
+
+func (o Outputs) ArtifactsKey(appVersion string) string {
+	tmpl := o.ArtifactsKeyTemplate
+	if tmpl == "" {
+		tmpl = "{{app-version}}"
+	}
+	return strings.Replace(tmpl, KeyTemplateAppVersion, appVersion, -1)
 }

--- a/aws/s3/upload_dir_artifact.go
+++ b/aws/s3/upload_dir_artifact.go
@@ -8,11 +8,13 @@ import (
 	"os"
 )
 
-func UploadArtifact(ctx context.Context, infra Outputs, source string, filepaths []string, version string) error {
+func UploadDirArtifact(ctx context.Context, infra Outputs, source string, filepaths []string, version string) error {
+	objDir := infra.ArtifactsKey(version)
+
 	logger := log.New(os.Stderr, "", 0)
 	uploader := nsaws.S3Uploader{
-		BucketName:      infra.BucketName,
-		ObjectDirectory: version,
+		BucketName:      infra.ArtifactsBucketName,
+		ObjectDirectory: objDir,
 		OnObjectUpload: func(objectKey string) {
 			logger.Println(fmt.Sprintf("Uploaded %s", objectKey))
 		},

--- a/aws/s3/upload_zip_artifact.go
+++ b/aws/s3/upload_zip_artifact.go
@@ -1,4 +1,4 @@
-package lambda_zip
+package s3
 
 import (
 	"context"
@@ -11,7 +11,7 @@ import (
 	"io"
 )
 
-func UploadArtifact(ctx context.Context, infra Outputs, content io.ReadSeeker, version string) error {
+func UploadZipArtifact(ctx context.Context, infra Outputs, content io.ReadSeeker, version string) error {
 	s3Client := s3.NewFromConfig(nsaws.NewConfig(infra.Deployer, infra.Region))
 
 	// Calculate md5 content to add as header (necessary for s3 buckets that have object lock enabled)

--- a/aws/s3/zip_pusher.go
+++ b/aws/s3/zip_pusher.go
@@ -1,4 +1,4 @@
-package lambda_zip
+package s3
 
 import (
 	"context"
@@ -10,25 +10,25 @@ import (
 	"os"
 )
 
-func NewPusher(osWriters logging.OsWriters, nsConfig api.Config, appDetails app.Details) (app.Pusher, error) {
+func NewZipPusher(osWriters logging.OsWriters, nsConfig api.Config, appDetails app.Details) (app.Pusher, error) {
 	outs, err := outputs.Retrieve[Outputs](nsConfig, appDetails.Workspace)
 	if err != nil {
 		return nil, err
 	}
-	return &Pusher{
+	return &ZipPusher{
 		OsWriters: osWriters,
 		NsConfig:  nsConfig,
 		Infra:     outs,
 	}, nil
 }
 
-type Pusher struct {
+type ZipPusher struct {
 	OsWriters logging.OsWriters
 	NsConfig  api.Config
 	Infra     Outputs
 }
 
-func (p Pusher) Push(ctx context.Context, source, version string) error {
+func (p ZipPusher) Push(ctx context.Context, source, version string) error {
 	stdout, _ := p.OsWriters.Stdout(), p.OsWriters.Stderr()
 
 	if source == "" {
@@ -47,7 +47,7 @@ func (p Pusher) Push(ctx context.Context, source, version string) error {
 	defer file.Close()
 
 	fmt.Fprintf(stdout, "Uploading %s to artifacts bucket\n", p.Infra.ArtifactsKey(version))
-	if err := UploadArtifact(ctx, p.Infra, file, version); err != nil {
+	if err := UploadZipArtifact(ctx, p.Infra, file, version); err != nil {
 		return fmt.Errorf("error uploading artifact: %w", err)
 	}
 

--- a/aws/s3/zip_pusher.go
+++ b/aws/s3/zip_pusher.go
@@ -17,14 +17,12 @@ func NewZipPusher(osWriters logging.OsWriters, nsConfig api.Config, appDetails a
 	}
 	return &ZipPusher{
 		OsWriters: osWriters,
-		NsConfig:  nsConfig,
 		Infra:     outs,
 	}, nil
 }
 
 type ZipPusher struct {
 	OsWriters logging.OsWriters
-	NsConfig  api.Config
 	Infra     Outputs
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,12 +9,12 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.18.4
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.17.8
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.18.11
+	github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.14.9
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.23.4
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.27.1
 	github.com/aws/smithy-go v1.12.0
 	github.com/docker/cli v20.10.9+incompatible
 	github.com/docker/docker v20.10.17+incompatible
-	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6
 	github.com/nullstone-io/module v0.2.8
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
@@ -59,6 +59,7 @@ require (
 	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
 	github.com/moby/sys/mount v0.2.0 // indirect
 	github.com/moby/sys/mountinfo v0.4.1 // indirect
+	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ github.com/aws/aws-sdk-go-v2/service/ecr v1.17.8 h1:wgZo/yeY0f+2RWy2q1rTtZSPMmq3
 github.com/aws/aws-sdk-go-v2/service/ecr v1.17.8/go.mod h1:ItZADKTnGxqcqXABHyNpoBljQ8ORt4h+D39RToM/3Ds=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.18.11 h1:MWJBTtfIwBJJn7AMYiyvc2g62HUAxJ+RujN2rMYPzVI=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.18.11/go.mod h1:3+9Tsuq6J9nezo2AO9UYzUVgZ72W21Ryh0d+DJRCzys=
+github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.14.9 h1:78ENf49ag/glp/z+6NR2lEoXWsnlHZUK1JLs5eNSm+M=
+github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.14.9/go.mod h1:BY71CNhZ9kzmpcDwKsPzyf1xt5PADO/+4Wmnopgyv6o=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.3.0/go.mod h1:v8ygadNyATSm6elwJ/4gzJwcFhri9RqS8skgHKiwXPU=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.3 h1:4n4KCtv5SUoT5Er5XV41huuzrCqepxlW3SDI9qHQebc=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.3/go.mod h1:gkb2qADY+OHaGLKNTYxMaQNacfeyQpZ4csDTQMeFmcw=

--- a/logging/os_writers.go
+++ b/logging/os_writers.go
@@ -3,6 +3,7 @@ package logging
 import (
 	"context"
 	"io"
+	"os"
 )
 
 // OsWriters contains two io.Writers that are used to write to stdout/stderr
@@ -23,3 +24,10 @@ func OsWritersFromContext(ctx context.Context) OsWriters {
 func ContextWithOsWriters(ctx context.Context, osWriters OsWriters) context.Context {
 	return context.WithValue(ctx, contextKey{}, osWriters)
 }
+
+var _ OsWriters = StandardOsWriters{}
+
+type StandardOsWriters struct{}
+
+func (w StandardOsWriters) Stdout() io.Writer { return os.Stdout }
+func (w StandardOsWriters) Stderr() io.Writer { return os.Stderr }


### PR DESCRIPTION
Added beanstalk app Provider.
To do this, I added the following:
- Created beanstalk Pusher, Deployer, DeployStatusGetter.
- Added `StandardOsWriters` that implements `OsWriters` with `os.Stdout` and `os.Stderr`.
- Dropped superfluous fields in pushers, deployers, and deploy status getters.
- Migrated lambda_zip.Pusher to s3.ZipPusher (used by lambda zip provider)
  - New beanstalk Pusher utilizes s3.ZipPusher, then creates an application version
- Renamed s3.Pusher to s3.DirPusher (used by static site provider)
- Aligned both pusher contracts to utilize `artifacts_bucket_name` and `artifacts_key_template` outputs from modules