### PR TITLE
C1011 deploy immediate

### DIFF
--- a/app/container/aws-ecs-ec2/provider.go
+++ b/app/container/aws-ecs-ec2/provider.go
@@ -16,6 +16,7 @@ var ModuleContractName = types.ModuleContractName{
 }
 
 var Provider = app.Provider{
+	CanDeployImmediate:    false,
 	NewPusher:             ecr.NewPusher,
 	NewDeployer:           ecs.NewDeployer,
 	NewDeployStatusGetter: ecs.NewDeployStatusGetter,

--- a/app/container/aws-ecs-fargate/provider.go
+++ b/app/container/aws-ecs-fargate/provider.go
@@ -16,6 +16,7 @@ var ModuleContractName = types.ModuleContractName{
 }
 
 var Provider = app.Provider{
+	CanDeployImmediate:    false,
 	NewPusher:             ecr.NewPusher,
 	NewDeployer:           ecs.NewDeployer,
 	NewDeployStatusGetter: ecs.NewDeployStatusGetter,

--- a/app/provider.go
+++ b/app/provider.go
@@ -7,6 +7,7 @@ import (
 )
 
 type Provider struct {
+	CanDeployImmediate    bool
 	NewPusher             NewPusherFunc
 	NewDeployer           NewDeployerFunc
 	NewDeployStatusGetter NewDeployStatusGetterFunc

--- a/app/server/aws-beanstalk/provider.go
+++ b/app/server/aws-beanstalk/provider.go
@@ -15,6 +15,7 @@ var ModuleContractName = types.ModuleContractName{
 }
 
 var Provider = app.Provider{
+	CanDeployImmediate:    false,
 	NewPusher:             beanstalk.NewPusher,
 	NewDeployer:           beanstalk.NewDeployer,
 	NewDeployStatusGetter: beanstalk.NewDeployStatusGetter,

--- a/app/serverless/aws-lambda-container/provider.go
+++ b/app/serverless/aws-lambda-container/provider.go
@@ -16,6 +16,7 @@ var ModuleContractName = types.ModuleContractName{
 }
 
 var Provider = app.Provider{
+	CanDeployImmediate:    true,
 	NewPusher:             ecr.NewPusher,
 	NewDeployer:           lambda_container.NewDeployer,
 	NewDeployStatusGetter: nil,

--- a/app/serverless/aws-lambda-zip/provider.go
+++ b/app/serverless/aws-lambda-zip/provider.go
@@ -16,6 +16,7 @@ var ModuleContractName = types.ModuleContractName{
 }
 
 var Provider = app.Provider{
+	CanDeployImmediate:    true,
 	NewPusher:             s3.NewZipPusher,
 	NewDeployer:           lambda_zip.NewDeployer,
 	NewDeployStatusGetter: nil,

--- a/app/static-site/aws-s3/provider.go
+++ b/app/static-site/aws-s3/provider.go
@@ -16,6 +16,7 @@ var ModuleContractName = types.ModuleContractName{
 }
 
 var Provider = app.Provider{
+	CanDeployImmediate:    true,
 	NewPusher:             s3.NewDirPusher,
 	NewDeployer:           cdn.NewDeployer,
 	NewDeployStatusGetter: cdn.NewDeployStatusGetter,

--- a/aws/beanstalk/deploy_status_getter.go
+++ b/aws/beanstalk/deploy_status_getter.go
@@ -67,7 +67,7 @@ func (d DeployStatusGetter) mapRolloutStatus(env *ebtypes.EnvironmentDescription
 		// fall through to check health status
 	}
 
-	fmt.Fprintf(stdout,"Awaiting environment health to become healthy (currently: %s)\n", env.Health)
+	fmt.Fprintf(stdout, "Awaiting environment health to become healthy (currently: %s)\n", env.Health)
 	switch env.Health {
 	case ebtypes.EnvironmentHealthGreen:
 		return app.RolloutStatusComplete

--- a/aws/beanstalk/update_environment.go
+++ b/aws/beanstalk/update_environment.go
@@ -16,4 +16,3 @@ func UpdateEnvironment(ctx context.Context, infra Outputs, version string) error
 	})
 	return err
 }
-


### PR DESCRIPTION
This adds a marker to app providers that indicate that the provider deployment is fast-running:
- Runs in < 1 minute
- Doesn't require special resources like a docker daemon
