### PR TITLE
F/1209/versioned assets

### DIFF
--- a/aws/cdn/deployer.go
+++ b/aws/cdn/deployer.go
@@ -62,6 +62,7 @@ func (d Deployer) Deploy(ctx context.Context, meta app.DeployMetadata) (string, 
 		// NOTE: We only know how to return a single CDN invalidation ID
 		//       The first iteration of the loop will return the first one
 		for _, invalidationId := range invalidationIds {
+			fmt.Fprintf(stdout, "Deployed app %q\n", d.Details.App.Name)
 			return invalidationId, nil
 		}
 	}

--- a/aws/cdn/deployer.go
+++ b/aws/cdn/deployer.go
@@ -30,6 +30,7 @@ type Deployer struct {
 }
 
 func (d Deployer) Deploy(ctx context.Context, meta app.DeployMetadata) (string, error) {
+	ctx = logging.ContextWithOsWriters(ctx, d.OsWriters)
 	stdout, _ := d.OsWriters.Stdout(), d.OsWriters.Stderr()
 
 	fmt.Fprintf(stdout, "Deploying app %q\n", d.Details.App.Name)

--- a/aws/cdn/outputs.go
+++ b/aws/cdn/outputs.go
@@ -17,9 +17,5 @@ type Outputs struct {
 }
 
 func (o Outputs) ArtifactsKey(appVersion string) string {
-	tmpl := o.ArtifactsKeyTemplate
-	if tmpl == "" {
-		tmpl = "{{app-version}}"
-	}
-	return strings.Replace(tmpl, KeyTemplateAppVersion, appVersion, -1)
+	return strings.Replace(o.ArtifactsKeyTemplate, KeyTemplateAppVersion, appVersion, -1)
 }

--- a/aws/cdn/outputs.go
+++ b/aws/cdn/outputs.go
@@ -2,10 +2,24 @@ package cdn
 
 import (
 	"github.com/nullstone-io/deployment-sdk/aws"
+	"strings"
+)
+
+const (
+	KeyTemplateAppVersion = "{{app-version}}"
 )
 
 type Outputs struct {
-	Region   string     `ns:"region"`
-	Deployer nsaws.User `ns:"deployer"`
-	CdnIds   []string   `ns:"cdn_ids"`
+	Region               string     `ns:"region"`
+	Deployer             nsaws.User `ns:"deployer"`
+	CdnIds               []string   `ns:"cdn_ids"`
+	ArtifactsKeyTemplate string     `ns:"artifacts_key_template,optional"`
+}
+
+func (o Outputs) ArtifactsKey(appVersion string) string {
+	tmpl := o.ArtifactsKeyTemplate
+	if tmpl == "" {
+		tmpl = "{{app-version}}"
+	}
+	return strings.Replace(tmpl, KeyTemplateAppVersion, appVersion, -1)
 }

--- a/aws/cdn/update_cdn_version.go
+++ b/aws/cdn/update_cdn_version.go
@@ -2,11 +2,13 @@ package cdn
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
 	cftypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
 	"github.com/nullstone-io/deployment-sdk/aws"
+	"github.com/nullstone-io/deployment-sdk/logging"
 	"strings"
 )
 
@@ -34,6 +36,9 @@ func UpdateCdnVersion(ctx context.Context, infra Outputs, version string) (bool,
 			IfMatch:            cdnRes.ETag,
 		})
 		if err != nil {
+			writers := logging.OsWritersFromContext(ctx)
+			raw, _ := json.Marshal(dc)
+			fmt.Fprintf(writers.Stderr(), "distribution config: %s\n", string(raw))
 			return false, fmt.Errorf("error updating distribution %q: %w", *cdnRes.Distribution.Id, err)
 		}
 	}

--- a/aws/cdn/update_cdn_version.go
+++ b/aws/cdn/update_cdn_version.go
@@ -45,7 +45,8 @@ func UpdateCdnVersion(ctx context.Context, infra Outputs, version string) (bool,
 func coerceValidOriginPath(artifactsDir string) string {
 	// Ensure there is a preceding `/` and no trailing `/`
 	// Coerce value of `/` to empty string (`/` is invalid)
-	return strings.TrimSuffix(strings.TrimPrefix(artifactsDir, "/"), "/")
+	dir := fmt.Sprintf("/%s", strings.TrimPrefix(artifactsDir, "/"))
+	return strings.TrimSuffix(dir, "/")
 }
 
 // calcDistributionConfig makes changes to the distribution config for a deployment

--- a/aws/cdn/update_cdn_version.go
+++ b/aws/cdn/update_cdn_version.go
@@ -52,6 +52,8 @@ func coerceValidOriginPath(artifactsDir string) string {
 // If the distribution does not have a default origin, we return a nil config which signifies that we don't support updates
 // This also returns a bool that indicates whether any changes were made to the distribution config
 func calcDistributionConfig(ctx context.Context, cdn *cftypes.Distribution, newOriginPath string) (bool, *cftypes.DistributionConfig) {
+	stdout := logging.OsWritersFromContext(ctx).Stdout()
+
 	index, defaultOrigin := findDefaultOrigin(cdn)
 	if index < 0 {
 		// This only knows how to update the version on the default origin for a CDN
@@ -62,9 +64,7 @@ func calcDistributionConfig(ctx context.Context, cdn *cftypes.Distribution, newO
 	changed := oldOriginPath != newOriginPath
 	dc := cdn.DistributionConfig
 	dc.Origins.Items[index].OriginPath = aws.String(newOriginPath)
-	if writers := logging.OsWritersFromContext(ctx); writers != nil {
-		fmt.Fprintf(writers.Stdout(), "Updating CDN origin path to %q\n", newOriginPath)
-	}
+	fmt.Fprintf(stdout, "Updating CDN origin path to %q\n", newOriginPath)
 	return changed, dc
 }
 

--- a/aws/cdn/update_cdn_version.go
+++ b/aws/cdn/update_cdn_version.go
@@ -70,21 +70,6 @@ func findDefaultOrigin(cdn *cftypes.Distribution) (int, cftypes.Origin) {
 	return -1, cftypes.Origin{}
 }
 
-func replaceOriginPath(cdn *cloudfront.GetDistributionOutput, newOriginPath string) *cftypes.DistributionConfig {
-	primaryOriginId := getDefaultOriginId(cdn.Distribution)
-	dc := cdn.Distribution.DistributionConfig
-	if primaryOriginId == "" {
-		return dc
-	}
-
-	for i, item := range dc.Origins.Items {
-		if *item.Id == primaryOriginId {
-			dc.Origins.Items[i].OriginPath = aws.String(fmt.Sprintf("/%s", newOriginPath))
-		}
-	}
-	return dc
-}
-
 func getDefaultOriginId(cdn *cftypes.Distribution) string {
 	if cdn == nil || cdn.DistributionConfig == nil || cdn.DistributionConfig.DefaultCacheBehavior == nil {
 		return ""

--- a/aws/cdn/update_cdn_version.go
+++ b/aws/cdn/update_cdn_version.go
@@ -9,25 +9,65 @@ import (
 	"github.com/nullstone-io/deployment-sdk/aws"
 )
 
-func UpdateCdnVersion(ctx context.Context, infra Outputs, version string) error {
+// UpdateCdnVersion updates the cloudfront distribution with the appropriate app version
+// This returns a false result if no changes were made to the distribution
+func UpdateCdnVersion(ctx context.Context, infra Outputs, version string) (bool, error) {
 	cdns, err := GetCdns(ctx, infra)
 	if err != nil {
-		return err
+		return false, err
 	}
 
+	hasChanges := false
+	newOriginPath := infra.ArtifactsKey(version)
 	cfClient := nsaws.NewCloudfrontClient(infra.Deployer, infra.Region)
 	for _, cdnRes := range cdns {
+		changed, dc := calcDistributionConfig(cdnRes.Distribution, newOriginPath)
+		if !changed || dc == nil {
+			// We don't update the distribution if there were no changes or we don't support making changes
+			continue
+		}
+		hasChanges = true
 		_, err := cfClient.UpdateDistribution(ctx, &cloudfront.UpdateDistributionInput{
-			DistributionConfig: replaceOriginPath(cdnRes, version),
+			DistributionConfig: dc,
 			Id:                 cdnRes.Distribution.Id,
 			IfMatch:            cdnRes.ETag,
 		})
 		if err != nil {
-			return fmt.Errorf("error updating distribution %q: %w", *cdnRes.Distribution.Id, err)
+			return false, fmt.Errorf("error updating distribution %q: %w", *cdnRes.Distribution.Id, err)
 		}
 	}
 
-	return err
+	return hasChanges, err
+}
+
+// calcDistributionConfig makes changes to the distribution config for a deployment
+// If the distribution does not have a default origin, we return a nil config which signifies that we don't support updates
+// This also returns a bool that indicates whether any changes were made to the distribution config
+func calcDistributionConfig(cdn *cftypes.Distribution, newOriginPath string) (bool, *cftypes.DistributionConfig) {
+	index, defaultOrigin := findDefaultOrigin(cdn)
+	if index < 0 {
+		// This only knows how to update the version on the default origin for a CDN
+		// If there is no default origin, skip it
+		return false, nil
+	}
+	oldOriginPath := *defaultOrigin.OriginPath
+	changed := oldOriginPath != newOriginPath
+	dc := cdn.DistributionConfig
+	dc.Origins.Items[index].OriginPath = aws.String(newOriginPath)
+	return changed, dc
+}
+
+func findDefaultOrigin(cdn *cftypes.Distribution) (int, cftypes.Origin) {
+	defaultOriginId := getDefaultOriginId(cdn)
+	if defaultOriginId == "" {
+		return -1, cftypes.Origin{}
+	}
+	for i, item := range cdn.DistributionConfig.Origins.Items {
+		if *item.Id == defaultOriginId {
+			return i, item
+		}
+	}
+	return -1, cftypes.Origin{}
 }
 
 func replaceOriginPath(cdn *cloudfront.GetDistributionOutput, newOriginPath string) *cftypes.DistributionConfig {

--- a/aws/ecs/deployer.go
+++ b/aws/ecs/deployer.go
@@ -36,11 +36,12 @@ func (d Deployer) Print() {
 }
 
 // Deploy takes the following steps to deploy an AWS ECS service
-//   Get task definition
-//   Change image tag in task definition
-//   Register new task definition
-//   Deregister old task definition
-//   Update ECS Service (This always causes deployment)
+//
+//	Get task definition
+//	Change image tag in task definition
+//	Register new task definition
+//	Deregister old task definition
+//	Update ECS Service (This always causes deployment)
 func (d Deployer) Deploy(ctx context.Context, meta app.DeployMetadata) (string, error) {
 	stdout, _ := d.OsWriters.Stdout(), d.OsWriters.Stderr()
 	d.Print()

--- a/aws/lambda-container/deployer.go
+++ b/aws/lambda-container/deployer.go
@@ -50,7 +50,7 @@ func (d Deployer) Deploy(ctx context.Context, meta app.DeployMetadata) (string, 
 		return "", fmt.Errorf("error retrieving lambda configuration: %w", err)
 	}
 	updates := lambda.MapFunctionConfig(config)
-	updates.Environment.Variables = env_vars.UpdateStandard(updates.Environment.Variables, meta)
+	env_vars.UpdateStandard(updates.Environment.Variables, meta)
 	if err := nslambda.UpdateFunctionConfig(ctx, d.Infra, updates); err != nil {
 		return "", fmt.Errorf("error updating lambda configuration: %w", err)
 	}

--- a/aws/lambda-zip/deployer.go
+++ b/aws/lambda-zip/deployer.go
@@ -50,7 +50,7 @@ func (d Deployer) Deploy(ctx context.Context, meta app.DeployMetadata) (string, 
 		return "", fmt.Errorf("error retrieving lambda configuration: %w", err)
 	}
 	updates := lambda.MapFunctionConfig(config)
-	updates.Environment.Variables = env_vars.UpdateStandard(updates.Environment.Variables, meta)
+	env_vars.UpdateStandard(updates.Environment.Variables, meta)
 	if err := nslambda.UpdateFunctionConfig(ctx, d.Infra, updates); err != nil {
 		return "", fmt.Errorf("error updating lambda configuration: %w", err)
 	}

--- a/aws/s3/deployer.go
+++ b/aws/s3/deployer.go
@@ -64,7 +64,7 @@ func (d Deployer) updateEnvVars(ctx context.Context, meta app.DeployMetadata) er
 	if err != nil {
 		return err
 	}
-	envVars = env_vars.UpdateStandard(envVars, meta)
+	env_vars.UpdateStandard(envVars, meta)
 	if err := PutEnvVars(ctx, d.Infra, envVars); err != nil {
 		return err
 	}

--- a/aws/s3/deployer.go
+++ b/aws/s3/deployer.go
@@ -32,6 +32,7 @@ type Deployer struct {
 }
 
 func (d Deployer) Deploy(ctx context.Context, meta app.DeployMetadata) (string, error) {
+	ctx = logging.ContextWithOsWriters(ctx, d.OsWriters)
 	stdout, _ := d.OsWriters.Stdout(), d.OsWriters.Stderr()
 
 	if len(d.Infra.CdnIds) < 1 {

--- a/aws/s3/deployer.go
+++ b/aws/s3/deployer.go
@@ -62,7 +62,6 @@ func (d Deployer) updateEnvVars(ctx context.Context, meta app.DeployMetadata) (b
 		return false, nil
 	}
 
-	fmt.Fprintf(stdout, "Updating environment variables s3 object %q\n", d.Infra.EnvVarsFilename)
 	original, err := GetEnvVars(ctx, d.Infra)
 	if err != nil {
 		return false, err
@@ -76,5 +75,6 @@ func (d Deployer) updateEnvVars(ctx context.Context, meta app.DeployMetadata) (b
 	if reflect.DeepEqual(original, updated) {
 		return false, nil
 	}
+	fmt.Fprintf(stdout, "Updating environment variables s3 object %q\n", d.Infra.EnvVarsFilename)
 	return true, PutEnvVars(ctx, d.Infra, updated)
 }

--- a/aws/s3/deployer.go
+++ b/aws/s3/deployer.go
@@ -65,7 +65,7 @@ func (d Deployer) updateEnvVars(ctx context.Context, meta app.DeployMetadata) er
 		return err
 	}
 	envVars = env_vars.UpdateStandard(envVars, meta)
-	if err := PutEnVars(ctx, d.Infra, envVars); err != nil {
+	if err := PutEnvVars(ctx, d.Infra, envVars); err != nil {
 		return err
 	}
 	return nil

--- a/aws/s3/outputs.go
+++ b/aws/s3/outputs.go
@@ -19,9 +19,5 @@ type Outputs struct {
 }
 
 func (o Outputs) ArtifactsKey(appVersion string) string {
-	tmpl := o.ArtifactsKeyTemplate
-	if tmpl == "" {
-		tmpl = "{{app-version}}"
-	}
-	return strings.Replace(tmpl, KeyTemplateAppVersion, appVersion, -1)
+	return strings.Replace(o.ArtifactsKeyTemplate, KeyTemplateAppVersion, appVersion, -1)
 }

--- a/aws/s3/put_env_vars.go
+++ b/aws/s3/put_env_vars.go
@@ -9,7 +9,7 @@ import (
 	nsaws "github.com/nullstone-io/deployment-sdk/aws"
 )
 
-func PutEnVars(ctx context.Context, infra Outputs, envVars map[string]string) error {
+func PutEnvVars(ctx context.Context, infra Outputs, envVars map[string]string) error {
 	raw, _ := json.Marshal(envVars)
 
 	s3Client := s3.NewFromConfig(nsaws.NewConfig(infra.Deployer, infra.Region))

--- a/env-vars/standard.go
+++ b/env-vars/standard.go
@@ -15,9 +15,10 @@ func GetStandard(meta app.DeployMetadata) map[string]string {
 // Essentially, we rely on the Terraform plan to be the source of truth for what env vars are included/excluded
 func UpdateStandard(cur map[string]string, meta app.DeployMetadata) {
 	std := GetStandard(meta)
-	for k := range cur {
-		if val, ok := std[k]; ok {
-			cur[k] = val
+	for k, v := range std {
+		// We don't want to introduce new env vars, only modify existing
+		if _, exists := cur[k]; exists {
+			cur[k] = v
 		}
 	}
 }

--- a/env-vars/standard.go
+++ b/env-vars/standard.go
@@ -13,13 +13,11 @@ func GetStandard(meta app.DeployMetadata) map[string]string {
 // This does not add new env vars, only replaces existing ones
 // Otherwise, this could cause thrashing between code deploys and terraform plans
 // Essentially, we rely on the Terraform plan to be the source of truth for what env vars are included/excluded
-func UpdateStandard(existing map[string]string, meta app.DeployMetadata) map[string]string {
+func UpdateStandard(cur map[string]string, meta app.DeployMetadata) {
 	std := GetStandard(meta)
-	updated := existing
-	for k := range existing {
+	for k := range cur {
 		if val, ok := std[k]; ok {
-			std[k] = val
+			cur[k] = val
 		}
 	}
-	return updated
 }

--- a/outputs/field.go
+++ b/outputs/field.go
@@ -21,22 +21,24 @@ Field is a representation of a struct tag that is specific to nullstone outputs
 You can define an output mapping directly to a workspace or to outputs through a connection in that workspace
 
 Examples:
-type Outputs struct {
-  Output1        string            `ns:"output1"`
-  OptionalOutput string            `ns:"optional_output,optional"`
-  MapOutput      map[string]string `ns:"map_output"`
 
-  Dependency DependencyOutputs `ns:",connectionType:some-dependency"`
-}
+	type Outputs struct {
+	  Output1        string            `ns:"output1"`
+	  OptionalOutput string            `ns:"optional_output,optional"`
+	  MapOutput      map[string]string `ns:"map_output"`
 
-type DependencyOutputs struct {
-  Output2 string `ns:"output2"`
-}
+	  Dependency DependencyOutputs `ns:",connectionType:some-dependency"`
+	}
+
+	type DependencyOutputs struct {
+	  Output2 string `ns:"output2"`
+	}
 
 Notes:
-  All fields that that map connections must be a well-defined struct
-  If you want to ignore a member in the struct, use `ns:"-"`
-  If you want to make a field/connection optional, add `ns:"output,optional"`
+
+	All fields that that map connections must be a well-defined struct
+	If you want to ignore a member in the struct, use `ns:"-"`
+	If you want to make a field/connection optional, add `ns:"output,optional"`
 */
 type Field struct {
 	Field              reflect.StructField


### PR DESCRIPTION
This adds support for versioned assets to the deployment engine.

### Changes
- The CDN deployer uses the `artifacts_key_template` output from the module as the origin path.
- We no longer invalidate the CDN if the distribution wasn't changed.
- The helper function to update a map of env vars is done in-place to prevent confusion about how the function works.