### PR TITLE
Ensuring ecs deployment fails immediately if it doesn't exist

### DIFF
--- a/aws/ecs/deploy_status_getter.go
+++ b/aws/ecs/deploy_status_getter.go
@@ -71,7 +71,8 @@ func (d *DeployStatusGetter) GetDeployStatus(ctx context.Context, reference stri
 	deployment, err := GetDeployment(ctx, d.Infra, reference)
 	if err != nil {
 		if err == ErrNoDeployment {
-			return app.RolloutStatusFailed, fmt.Errorf("deployment %s does not exist", reference)
+			fmt.Fprintf(stdout, "Deployment %s does not exist", reference)
+			return app.RolloutStatusFailed, nil
 		}
 		return app.RolloutStatusUnknown, err
 	}


### PR DESCRIPTION
A deployment was evicted by another deployment.
When this happens, we see this in the evicted deployment logs.
(This happens until the deploy times out)
```
error occurred fetching the deployment status from the provider: deployment ecs-svc/9842249782313210570 does not exist
error occurred fetching the deployment status from the provider: deployment ecs-svc/9842249782313210570 does not exist
error occurred fetching the deployment status from the provider: deployment ecs-svc/9842249782313210570 does not exist
error occurred fetching the deployment status from the provider: deployment ecs-svc/9842249782313210570 does not exist
error occurred fetching the deployment status from the provider: deployment ecs-svc/9842249782313210570 does not exist
error occurred fetching the deployment status from the provider: deployment ecs-svc/9842249782313210570 does not exist
error occurred fetching the deployment status from the provider: deployment ecs-svc/9842249782313210570 does not exist
error occurred fetching the deployment status from the provider: deployment ecs-svc/9842249782313210570 does not exist
```

This change ensures that the deploy fails immediately, but still prints the error message to the build/deploy logs.