### PR TITLE
F/1352/cluster namespace

### DIFF
--- a/aws/ecs/deployer.go
+++ b/aws/ecs/deployer.go
@@ -30,7 +30,7 @@ type Deployer struct {
 
 func (d Deployer) Print() {
 	stdout, _ := d.OsWriters.Stdout(), d.OsWriters.Stderr()
-	fmt.Fprintf(stdout, "ecs cluster: %q\n", d.Infra.Cluster.ClusterArn)
+	fmt.Fprintf(stdout, "ecs cluster: %q\n", d.Infra.ClusterArn())
 	fmt.Fprintf(stdout, "ecs service: %q\n", d.Infra.ServiceName)
 	fmt.Fprintf(stdout, "repository image url: %q\n", d.Infra.ImageRepoUrl)
 }

--- a/aws/ecs/describe_tasks.go
+++ b/aws/ecs/describe_tasks.go
@@ -16,7 +16,7 @@ func DescribeTasks(ctx context.Context, infra Outputs, taskArns []string) ([]ecs
 
 	ecsClient := ecs.NewFromConfig(nsaws.NewConfig(infra.Deployer, infra.Region))
 	out, err := ecsClient.DescribeTasks(ctx, &ecs.DescribeTasksInput{
-		Cluster: aws.String(infra.Cluster.ClusterArn),
+		Cluster: aws.String(infra.ClusterArn()),
 		Tasks:   taskArns,
 	})
 	if err != nil {

--- a/aws/ecs/get_deployment_tasks.go
+++ b/aws/ecs/get_deployment_tasks.go
@@ -12,7 +12,7 @@ import (
 func GetDeploymentTasks(ctx context.Context, infra Outputs, deploymentId string) ([]ecstypes.Task, error) {
 	ecsClient := ecs.NewFromConfig(nsaws.NewConfig(infra.Deployer, infra.Region))
 	out, err := ecsClient.ListTasks(ctx, &ecs.ListTasksInput{
-		Cluster:     aws.String(infra.Cluster.ClusterArn),
+		Cluster:     aws.String(infra.ClusterArn()),
 		ServiceName: aws.String(infra.ServiceName),
 	})
 	if err != nil {
@@ -25,7 +25,7 @@ func GetDeploymentTasks(ctx context.Context, infra Outputs, deploymentId string)
 	}
 
 	out2, err := ecsClient.DescribeTasks(ctx, &ecs.DescribeTasksInput{
-		Cluster: aws.String(infra.Cluster.ClusterArn),
+		Cluster: aws.String(infra.ClusterArn()),
 		Tasks:   out.TaskArns,
 	})
 	if err != nil {

--- a/aws/ecs/get_service.go
+++ b/aws/ecs/get_service.go
@@ -12,7 +12,7 @@ func GetService(ctx context.Context, infra Outputs) (*ecstypes.Service, error) {
 	ecsClient := ecs.NewFromConfig(nsaws.NewConfig(infra.Deployer, infra.Region))
 	out, err := ecsClient.DescribeServices(ctx, &ecs.DescribeServicesInput{
 		Services: []string{infra.ServiceName},
-		Cluster:  aws.String(infra.Cluster.ClusterArn),
+		Cluster:  aws.String(infra.ClusterArn()),
 	})
 	if err != nil {
 		return nil, err

--- a/aws/ecs/get_service_tasks.go
+++ b/aws/ecs/get_service_tasks.go
@@ -12,7 +12,7 @@ import (
 func GetServiceTasks(ctx context.Context, infra Outputs) ([]ecstypes.Task, error) {
 	ecsClient := ecs.NewFromConfig(nsaws.NewConfig(infra.Deployer, infra.Region))
 	tasks, err := ecsClient.ListTasks(ctx, &ecs.ListTasksInput{
-		Cluster:     aws.String(infra.Cluster.ClusterArn),
+		Cluster:     aws.String(infra.ClusterArn()),
 		ServiceName: aws.String(infra.ServiceName),
 	})
 	if err != nil {
@@ -25,7 +25,7 @@ func GetServiceTasks(ctx context.Context, infra Outputs) ([]ecstypes.Task, error
 	}
 
 	out, err := ecsClient.DescribeTasks(ctx, &ecs.DescribeTasksInput{
-		Cluster: aws.String(infra.Cluster.ClusterArn),
+		Cluster: aws.String(infra.ClusterArn()),
 		Tasks:   tasks.TaskArns,
 	})
 	if err != nil {

--- a/aws/ecs/outputs.go
+++ b/aws/ecs/outputs.go
@@ -15,7 +15,7 @@ type Outputs struct {
 	Deployer          nsaws.User      `ns:"deployer,optional"`
 
 	Cluster          ClusterOutputs          `ns:",connectionContract:cluster/aws/ecs:*,optional"`
-	ClusterNamespace ClusterNamespaceOutputs `ns:"connectionContract:cluster/aws/ecs:*,optional"`
+	ClusterNamespace ClusterNamespaceOutputs `ns:",connectionContract:cluster-namespace/aws/ecs:*,optional"`
 }
 
 func (o Outputs) ClusterArn() string {

--- a/aws/ecs/outputs.go
+++ b/aws/ecs/outputs.go
@@ -14,7 +14,19 @@ type Outputs struct {
 	MainContainerName string          `ns:"main_container_name,optional"`
 	Deployer          nsaws.User      `ns:"deployer,optional"`
 
-	Cluster ClusterOutputs `ns:",connectionContract:cluster/aws/ecs:*"`
+	Cluster          ClusterOutputs          `ns:",connectionContract:cluster/aws/ecs:*,optional"`
+	ClusterNamespace ClusterNamespaceOutputs `ns:"connectionContract:cluster/aws/ecs:*,optional"`
+}
+
+func (o Outputs) ClusterArn() string {
+	if o.ClusterNamespace.ClusterArn != "" {
+		return o.ClusterNamespace.ClusterArn
+	}
+	return o.Cluster.ClusterArn
+}
+
+type ClusterNamespaceOutputs struct {
+	ClusterArn string `ns:"cluster_arn"`
 }
 
 type ClusterOutputs struct {

--- a/aws/ecs/update_service_task.go
+++ b/aws/ecs/update_service_task.go
@@ -15,7 +15,7 @@ func UpdateServiceTask(ctx context.Context, infra Outputs, newTaskDefArn string)
 
 	out, err := ecsClient.UpdateService(ctx, &ecs.UpdateServiceInput{
 		Service:            aws.String(infra.ServiceName),
-		Cluster:            aws.String(infra.Cluster.ClusterArn),
+		Cluster:            aws.String(infra.ClusterArn()),
 		ForceNewDeployment: true,
 		TaskDefinition:     aws.String(newTaskDefArn),
 	})

--- a/gcp/gke/deployer.go
+++ b/gcp/gke/deployer.go
@@ -37,7 +37,7 @@ type Deployer struct {
 
 func (d Deployer) Print() {
 	stdout, _ := d.OsWriters.Stdout(), d.OsWriters.Stderr()
-	fmt.Fprintf(stdout, "gke cluster: %q\n", d.Infra.ClusterNamespace.ClusterId)
+	fmt.Fprintf(stdout, "gke endpoint: %q\n", d.Infra.ClusterNamespace.ClusterEndpoint)
 	fmt.Fprintf(stdout, "gke service: %q\n", d.Infra.ServiceName)
 	fmt.Fprintf(stdout, "repository image url: %q\n", d.Infra.ImageRepoUrl)
 }

--- a/gcp/gke/outputs.go
+++ b/gcp/gke/outputs.go
@@ -18,28 +18,24 @@ type Outputs struct {
 }
 
 type ClusterNamespaceOutputs struct {
-	ClusterId            string `ns:"cluster_id"`
 	ClusterEndpoint      string `ns:"cluster_endpoint"`
 	ClusterCACertificate string `ns:"cluster_ca_certificate"`
 }
 
 func (o ClusterNamespaceOutputs) ClusterInfo() k8s.ClusterInfo {
 	return k8s.ClusterInfo{
-		ID:            o.ClusterId,
 		Endpoint:      o.ClusterEndpoint,
 		CACertificate: o.ClusterCACertificate,
 	}
 }
 
 type ClusterOutputs struct {
-	ClusterId            string `ns:"cluster_id"`
 	ClusterEndpoint      string `ns:"cluster_endpoint"`
 	ClusterCACertificate string `ns:"cluster_ca_certificate"`
 }
 
 func (o ClusterOutputs) ClusterInfo() k8s.ClusterInfo {
 	return k8s.ClusterInfo{
-		ID:            o.ClusterId,
 		Endpoint:      o.ClusterEndpoint,
 		CACertificate: o.ClusterCACertificate,
 	}

--- a/k8s/config_creator.go
+++ b/k8s/config_creator.go
@@ -19,7 +19,6 @@ type ClusterInfoer interface {
 }
 
 type ClusterInfo struct {
-	ID            string
 	Endpoint      string
 	CACertificate string
 }


### PR DESCRIPTION
This upgrades ECS apps to use a `cluster-namespace` instead of `cluster` connection.
This is a backward-compatible upgrade -- if the module contains a `cluster` connection, deployments will continue working.

Once reviewed and merged, we need to upgrade the go module in `enigma`, merge, and redeploy `enigma-builder` app.