### PR TITLE
F1429 gke deployment timeout

### DIFF
--- a/gcp/gke/deploy_status_getter.go
+++ b/gcp/gke/deploy_status_getter.go
@@ -84,7 +84,8 @@ func (d *DeployStatusGetter) GetDeployStatus(ctx context.Context, reference stri
 
 	rolloutStatus, err := k8s.MapRolloutStatus(*deployment)
 	if err != nil {
-		return rolloutStatus, err
+		fmt.Fprintln(stderr, err.Error())
+		return rolloutStatus, nil
 	}
 	if rolloutStatus == app.RolloutStatusUnknown || rolloutStatus == app.RolloutStatusComplete {
 		// We don't want to spit out information about replicas if the rollout is completed or unknown

--- a/k8s/map_rollout_status_test.go
+++ b/k8s/map_rollout_status_test.go
@@ -1,0 +1,47 @@
+package k8s
+
+import (
+	"fmt"
+	"github.com/nullstone-io/deployment-sdk/app"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/apps/v1"
+	"testing"
+)
+
+func TestMapRolloutStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		deployment v1.Deployment
+		want       app.RolloutStatus
+		err        error
+	}{
+		{
+			name: "timed out",
+			deployment: v1.Deployment{
+				Spec: v1.DeploymentSpec{},
+				Status: v1.DeploymentStatus{
+					Conditions: []v1.DeploymentCondition{
+						{
+							Type:   v1.DeploymentAvailable,
+							Reason: "SomethingElse",
+						},
+						{
+							Type:   v1.DeploymentProgressing,
+							Reason: TimedOutReason,
+						},
+					},
+				},
+			},
+			want: app.RolloutStatusFailed,
+			err:  fmt.Errorf("deployment failed because timed out (exceeding its deadline)"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := MapRolloutStatus(test.deployment)
+			assert.Equal(t, test.err, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}


### PR DESCRIPTION
This PR updates the GetDeployStatus method for GKE deployments to return the proper response when a timeout occurs. This method was returning an error which causes the wait-healthy step in the engine to just continue trying. By removing the error (and just logging it directly), the engine will now check the status (TimedOut) and stop waiting for healthy.

I also added a quick test to verify my sanity. It doesn't do much but no reason to throw it away. We can add more tests to check this functionality further.