### PR TITLE
Replace DeployStatusGetter with DeployWatcher

### DIFF
--- a/app/container/aws-ecs-ec2/provider.go
+++ b/app/container/aws-ecs-ec2/provider.go
@@ -16,8 +16,8 @@ var ModuleContractName = types.ModuleContractName{
 }
 
 var Provider = app.Provider{
-	CanDeployImmediate:    false,
-	NewPusher:             ecr.NewPusher,
-	NewDeployer:           ecs.NewDeployer,
-	NewDeployStatusGetter: ecs.NewDeployStatusGetter,
+	CanDeployImmediate: false,
+	NewPusher:          ecr.NewPusher,
+	NewDeployer:        ecs.NewDeployer,
+	NewDeployWatcher:   app.NewPollingDeployWatcher(ecs.NewDeployStatusGetter),
 }

--- a/app/container/aws-ecs-fargate/provider.go
+++ b/app/container/aws-ecs-fargate/provider.go
@@ -16,8 +16,8 @@ var ModuleContractName = types.ModuleContractName{
 }
 
 var Provider = app.Provider{
-	CanDeployImmediate:    false,
-	NewPusher:             ecr.NewPusher,
-	NewDeployer:           ecs.NewDeployer,
-	NewDeployStatusGetter: ecs.NewDeployStatusGetter,
+	CanDeployImmediate: false,
+	NewPusher:          ecr.NewPusher,
+	NewDeployer:        ecs.NewDeployer,
+	NewDeployWatcher:   app.NewPollingDeployWatcher(ecs.NewDeployStatusGetter),
 }

--- a/app/container/gcp-gke-service/provider.go
+++ b/app/container/gcp-gke-service/provider.go
@@ -16,8 +16,8 @@ var ModuleContractName = types.ModuleContractName{
 }
 
 var Provider = app.Provider{
-	CanDeployImmediate:    false,
-	NewPusher:             gcr.NewPusher,
-	NewDeployer:           gke.NewDeployer,
-	NewDeployStatusGetter: gke.NewDeployStatusGetter,
+	CanDeployImmediate: false,
+	NewPusher:          gcr.NewPusher,
+	NewDeployer:        gke.NewDeployer,
+	NewDeployWatcher:   app.NewPollingDeployWatcher(gke.NewDeployStatusGetter),
 }

--- a/app/polling_deploy_watcher.go
+++ b/app/polling_deploy_watcher.go
@@ -1,0 +1,95 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/nullstone-io/deployment-sdk/logging"
+	"gopkg.in/nullstone-io/go-api-client.v0"
+	"time"
+)
+
+const (
+	watchDefaultTimeout = 15 * time.Minute
+	watchDefaultDelay   = 5 * time.Second
+)
+
+var (
+	ErrTimeout   = errors.New("deployment timed out")
+	ErrFailed    = errors.New("deployment failed")
+	ErrCancelled = errors.New("deployment cancelled")
+)
+
+var _ DeployWatcher = &PollingDeployWatcher{}
+
+// PollingDeployWatcher watches a deployment using polling
+// The implementation supports cancellation and timeouts through a context.Context
+type PollingDeployWatcher struct {
+	StatusGetter DeployStatusGetter
+	OsWriters    logging.OsWriters
+	Details      Details
+}
+
+// NewPollingDeployWatcher wraps a DeployStatusGetter to provide polling support for watching a deployment
+func NewPollingDeployWatcher(statusGetterFn NewDeployStatusGetterFunc) NewDeployWatcherFunc {
+	return func(osWriters logging.OsWriters, nsConfig api.Config, appDetails Details) (DeployWatcher, error) {
+		statusGetter, err := statusGetterFn(osWriters, nsConfig, appDetails)
+		if err != nil {
+			return nil, err
+		}
+		return &PollingDeployWatcher{
+			StatusGetter: statusGetter,
+			OsWriters:    osWriters,
+			Details:      appDetails,
+		}, nil
+	}
+}
+
+// Watch polls the provider for rollout status on the deployment.
+// This is long-running and supports cancellation/timeout via ctx
+// This polls every 5s and times out after 15m
+// This function has the following return values:
+// - nil: deployment completed successfully
+// - ErrFailed: Deployment failed as reported by DeployStatusGetter.GetDeployStatus
+// - ErrCancelled: System cancelled via ctx
+// - ErrTimeout: ctx reached timeout or watcher reached 15m timeout
+func (s *PollingDeployWatcher) Watch(ctx context.Context, reference string) error {
+	stdout := s.OsWriters.Stdout()
+
+	if reference == "" {
+		fmt.Fprintf(stdout, "This deployment does not have to wait for any resource to become healthy.\n")
+		return nil
+	}
+
+	delay, timeout := watchDefaultDelay, watchDefaultTimeout
+	t1 := time.After(timeout)
+	for {
+		status, err := s.StatusGetter.GetDeployStatus(ctx, reference)
+		if err != nil {
+			// if for some reason we can't fetch the app status from the provider
+			// we are going to log the error and continue looping
+			// eventually the deploy will timeout and fail
+			fmt.Fprintf(stdout, "error occurred fetching the deployment status from the provider: %s\n", err)
+		} else {
+			if status == RolloutStatusFailed {
+				return ErrFailed
+			}
+			if status == RolloutStatusComplete {
+				return nil
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			if ctx.Err() == context.DeadlineExceeded {
+				return ErrTimeout
+			}
+			return ErrCancelled
+		case <-t1:
+			return ErrTimeout
+		case <-time.After(delay):
+			// Poll status again
+			continue
+		}
+	}
+}

--- a/app/provider.go
+++ b/app/provider.go
@@ -7,15 +7,16 @@ import (
 )
 
 type Provider struct {
-	CanDeployImmediate    bool
-	NewPusher             NewPusherFunc
-	NewDeployer           NewDeployerFunc
-	NewDeployStatusGetter NewDeployStatusGetterFunc
+	CanDeployImmediate bool
+	NewPusher          NewPusherFunc
+	NewDeployer        NewDeployerFunc
+	NewDeployWatcher   NewDeployWatcherFunc
 }
 
 type NewPusherFunc func(osWriters logging.OsWriters, nsConfig api.Config, appDetails Details) (Pusher, error)
 type NewDeployerFunc func(osWriters logging.OsWriters, nsConfig api.Config, appDetails Details) (Deployer, error)
 type NewDeployStatusGetterFunc func(osWriters logging.OsWriters, nsConfig api.Config, appDetails Details) (DeployStatusGetter, error)
+type NewDeployWatcherFunc func(osWriters logging.OsWriters, nsConfig api.Config, appDetails Details) (DeployWatcher, error)
 
 type Pusher interface {
 	Push(ctx context.Context, source, version string) error
@@ -27,4 +28,8 @@ type Deployer interface {
 
 type DeployStatusGetter interface {
 	GetDeployStatus(ctx context.Context, reference string) (RolloutStatus, error)
+}
+
+type DeployWatcher interface {
+	Watch(ctx context.Context, reference string) error
 }

--- a/app/providers.go
+++ b/app/providers.go
@@ -24,12 +24,12 @@ func (s Providers) FindDeployer(osWriters logging.OsWriters, nsConfig api.Config
 	return factory.NewDeployer(osWriters, nsConfig, appDetails)
 }
 
-func (s Providers) FindDeployStatusGetter(osWriters logging.OsWriters, nsConfig api.Config, appDetails Details) (DeployStatusGetter, error) {
+func (s Providers) FindDeployWatcher(osWriters logging.OsWriters, nsConfig api.Config, appDetails Details) (DeployWatcher, error) {
 	factory := s.FindFactory(*appDetails.Module)
-	if factory == nil || factory.NewDeployStatusGetter == nil {
+	if factory == nil || factory.NewDeployWatcher == nil {
 		return nil, nil
 	}
-	return factory.NewDeployStatusGetter(osWriters, nsConfig, appDetails)
+	return factory.NewDeployWatcher(osWriters, nsConfig, appDetails)
 }
 
 func (s Providers) FindFactory(curModule types.Module) *Provider {

--- a/app/server/aws-beanstalk/provider.go
+++ b/app/server/aws-beanstalk/provider.go
@@ -15,8 +15,8 @@ var ModuleContractName = types.ModuleContractName{
 }
 
 var Provider = app.Provider{
-	CanDeployImmediate:    false,
-	NewPusher:             beanstalk.NewPusher,
-	NewDeployer:           beanstalk.NewDeployer,
-	NewDeployStatusGetter: beanstalk.NewDeployStatusGetter,
+	CanDeployImmediate: false,
+	NewPusher:          beanstalk.NewPusher,
+	NewDeployer:        beanstalk.NewDeployer,
+	NewDeployWatcher:   app.NewPollingDeployWatcher(beanstalk.NewDeployStatusGetter),
 }

--- a/app/serverless/aws-lambda-container/provider.go
+++ b/app/serverless/aws-lambda-container/provider.go
@@ -16,8 +16,8 @@ var ModuleContractName = types.ModuleContractName{
 }
 
 var Provider = app.Provider{
-	CanDeployImmediate:    true,
-	NewPusher:             ecr.NewPusher,
-	NewDeployer:           lambda_container.NewDeployer,
-	NewDeployStatusGetter: nil,
+	CanDeployImmediate: true,
+	NewPusher:          ecr.NewPusher,
+	NewDeployer:        lambda_container.NewDeployer,
+	NewDeployWatcher:   nil,
 }

--- a/app/serverless/aws-lambda-zip/provider.go
+++ b/app/serverless/aws-lambda-zip/provider.go
@@ -16,8 +16,8 @@ var ModuleContractName = types.ModuleContractName{
 }
 
 var Provider = app.Provider{
-	CanDeployImmediate:    true,
-	NewPusher:             s3.NewZipPusher,
-	NewDeployer:           lambda_zip.NewDeployer,
-	NewDeployStatusGetter: nil,
+	CanDeployImmediate: true,
+	NewPusher:          s3.NewZipPusher,
+	NewDeployer:        lambda_zip.NewDeployer,
+	NewDeployWatcher:   nil,
 }

--- a/app/static-site/aws-s3/provider.go
+++ b/app/static-site/aws-s3/provider.go
@@ -16,8 +16,8 @@ var ModuleContractName = types.ModuleContractName{
 }
 
 var Provider = app.Provider{
-	CanDeployImmediate:    true,
-	NewPusher:             s3.NewDirPusher,
-	NewDeployer:           s3.NewDeployer,
-	NewDeployStatusGetter: cdn.NewDeployStatusGetter,
+	CanDeployImmediate: true,
+	NewPusher:          s3.NewDirPusher,
+	NewDeployer:        s3.NewDeployer,
+	NewDeployWatcher:   app.NewPollingDeployWatcher(cdn.NewDeployStatusGetter),
 }


### PR DESCRIPTION
This is a no-change refactor to accomplish the following:
1. Improve quality of logs by enabling use of stateful understanding of deployment.
  Can track status of deployment to provide logging on edge events. For example, we can report that an image is being pulled if we know that a fargate service is transitioning from provisioning to pending.
2. Make it possible to thoroughly test "wait healthy" with automated testing in a single repo.

The `DeployStatusGetter` on `app.Provider` is replaced with `DeployWatcher` interface.
All providers were updated to wrap their `DeployStatusGetter` with a `PollingDeployWatcher`, the wait-healthy implementation from enigma.