### PR TITLE
Add Provider.Statuser to report on the status of an app

### DIFF
--- a/app/container/aws-ecs-ec2/provider.go
+++ b/app/container/aws-ecs-ec2/provider.go
@@ -20,4 +20,5 @@ var Provider = app.Provider{
 	NewPusher:          ecr.NewPusher,
 	NewDeployer:        ecs.NewDeployer,
 	NewDeployWatcher:   app.NewPollingDeployWatcher(ecs.NewDeployStatusGetter),
+	NewStatuser:        nil,
 }

--- a/app/container/aws-ecs-ec2/provider.go
+++ b/app/container/aws-ecs-ec2/provider.go
@@ -20,5 +20,5 @@ var Provider = app.Provider{
 	NewPusher:          ecr.NewPusher,
 	NewDeployer:        ecs.NewDeployer,
 	NewDeployWatcher:   app.NewPollingDeployWatcher(ecs.NewDeployStatusGetter),
-	NewStatuser:        nil,
+	NewStatuser:        ecs.NewStatuser,
 }

--- a/app/container/aws-ecs-fargate/provider.go
+++ b/app/container/aws-ecs-fargate/provider.go
@@ -20,4 +20,5 @@ var Provider = app.Provider{
 	NewPusher:          ecr.NewPusher,
 	NewDeployer:        ecs.NewDeployer,
 	NewDeployWatcher:   app.NewPollingDeployWatcher(ecs.NewDeployStatusGetter),
+	NewStatuser:        nil,
 }

--- a/app/container/aws-ecs-fargate/provider.go
+++ b/app/container/aws-ecs-fargate/provider.go
@@ -20,5 +20,5 @@ var Provider = app.Provider{
 	NewPusher:          ecr.NewPusher,
 	NewDeployer:        ecs.NewDeployer,
 	NewDeployWatcher:   app.NewPollingDeployWatcher(ecs.NewDeployStatusGetter),
-	NewStatuser:        nil,
+	NewStatuser:        ecs.NewStatuser,
 }

--- a/app/container/gcp-gke-service/provider.go
+++ b/app/container/gcp-gke-service/provider.go
@@ -20,4 +20,5 @@ var Provider = app.Provider{
 	NewPusher:          gcr.NewPusher,
 	NewDeployer:        gke.NewDeployer,
 	NewDeployWatcher:   app.NewPollingDeployWatcher(gke.NewDeployStatusGetter),
+	NewStatuser:        nil,
 }

--- a/app/provider.go
+++ b/app/provider.go
@@ -11,12 +11,14 @@ type Provider struct {
 	NewPusher          NewPusherFunc
 	NewDeployer        NewDeployerFunc
 	NewDeployWatcher   NewDeployWatcherFunc
+	NewStatuser        NewStatuserFunc
 }
 
 type NewPusherFunc func(osWriters logging.OsWriters, nsConfig api.Config, appDetails Details) (Pusher, error)
 type NewDeployerFunc func(osWriters logging.OsWriters, nsConfig api.Config, appDetails Details) (Deployer, error)
 type NewDeployStatusGetterFunc func(osWriters logging.OsWriters, nsConfig api.Config, appDetails Details) (DeployStatusGetter, error)
 type NewDeployWatcherFunc func(osWriters logging.OsWriters, nsConfig api.Config, appDetails Details) (DeployWatcher, error)
+type NewStatuserFunc func(osWriters logging.OsWriters, nsConfig api.Config, appDetails Details) (Statuser, error)
 
 type Pusher interface {
 	Push(ctx context.Context, source, version string) error
@@ -32,4 +34,8 @@ type DeployStatusGetter interface {
 
 type DeployWatcher interface {
 	Watch(ctx context.Context, reference string) error
+}
+
+type Statuser interface {
+	Status(ctx context.Context) (any, error)
 }

--- a/app/providers.go
+++ b/app/providers.go
@@ -32,6 +32,14 @@ func (s Providers) FindDeployWatcher(osWriters logging.OsWriters, nsConfig api.C
 	return factory.NewDeployWatcher(osWriters, nsConfig, appDetails)
 }
 
+func (s Providers) FindStatuser(osWriters logging.OsWriters, nsConfig api.Config, appDetails Details) (Statuser, error) {
+	factory := s.FindFactory(*appDetails.Module)
+	if factory == nil || factory.NewStatuser == nil {
+		return nil, nil
+	}
+	return factory.NewStatuser(osWriters, nsConfig, appDetails)
+}
+
 func (s Providers) FindFactory(curModule types.Module) *Provider {
 	if len(curModule.ProviderTypes) <= 0 {
 		return nil

--- a/app/server/aws-beanstalk/provider.go
+++ b/app/server/aws-beanstalk/provider.go
@@ -19,4 +19,5 @@ var Provider = app.Provider{
 	NewPusher:          beanstalk.NewPusher,
 	NewDeployer:        beanstalk.NewDeployer,
 	NewDeployWatcher:   app.NewPollingDeployWatcher(beanstalk.NewDeployStatusGetter),
+	NewStatuser:        nil,
 }

--- a/app/serverless/aws-lambda-container/provider.go
+++ b/app/serverless/aws-lambda-container/provider.go
@@ -20,4 +20,5 @@ var Provider = app.Provider{
 	NewPusher:          ecr.NewPusher,
 	NewDeployer:        lambda_container.NewDeployer,
 	NewDeployWatcher:   nil,
+	NewStatuser:        nil,
 }

--- a/app/serverless/aws-lambda-zip/provider.go
+++ b/app/serverless/aws-lambda-zip/provider.go
@@ -20,4 +20,5 @@ var Provider = app.Provider{
 	NewPusher:          s3.NewZipPusher,
 	NewDeployer:        lambda_zip.NewDeployer,
 	NewDeployWatcher:   nil,
+	NewStatuser:        nil,
 }

--- a/app/static-site/aws-s3/provider.go
+++ b/app/static-site/aws-s3/provider.go
@@ -20,4 +20,5 @@ var Provider = app.Provider{
 	NewPusher:          s3.NewDirPusher,
 	NewDeployer:        s3.NewDeployer,
 	NewDeployWatcher:   app.NewPollingDeployWatcher(cdn.NewDeployStatusGetter),
+	NewStatuser:        nil,
 }

--- a/aws/ecs/get_service_health.go
+++ b/aws/ecs/get_service_health.go
@@ -1,0 +1,51 @@
+package ecs
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+)
+
+type ServiceHealth struct {
+	LoadBalancers []ServiceLoadBalancerHealth
+}
+
+type ServiceLoadBalancerHealth struct {
+	LoadBalancer ecstypes.LoadBalancer
+	TargetGroups []elbv2types.TargetHealthDescription
+}
+
+func GetServiceHealth(ctx context.Context, infra Outputs) (ServiceHealth, error) {
+	result := ServiceHealth{LoadBalancers: make([]ServiceLoadBalancerHealth, 0)}
+	svc, err := GetService(ctx, infra)
+	if err != nil {
+		return result, err
+	} else if svc == nil {
+		return result, nil
+	}
+
+	for _, lb := range svc.LoadBalancers {
+		slbh := ServiceLoadBalancerHealth{LoadBalancer: lb}
+		if lb.TargetGroupArn != nil {
+			healths, err := GetTargetGroupHealth(ctx, infra, *lb.TargetGroupArn)
+			if err != nil {
+				return result, err
+			}
+			slbh.TargetGroups = healths
+		}
+		result.LoadBalancers = append(result.LoadBalancers, slbh)
+	}
+	return result, nil
+}
+
+func (s ServiceHealth) FindByTargetId(targetId string) *elbv2types.TargetHealthDescription {
+	for _, lb := range s.LoadBalancers {
+		for _, tg := range lb.TargetGroups {
+			if targetId == aws.ToString(tg.Target.Id) {
+				return &tg
+			}
+		}
+	}
+	return nil
+}

--- a/aws/ecs/get_target_group_health.go
+++ b/aws/ecs/get_target_group_health.go
@@ -1,0 +1,20 @@
+package ecs
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/nullstone-io/deployment-sdk/aws"
+)
+
+func GetTargetGroupHealth(ctx context.Context, infra Outputs, targetGroupArn string) ([]elbv2types.TargetHealthDescription, error) {
+	elbClient := elasticloadbalancingv2.NewFromConfig(nsaws.NewConfig(infra.Deployer, infra.Region))
+	out, err := elbClient.DescribeTargetHealth(ctx, &elasticloadbalancingv2.DescribeTargetHealthInput{
+		TargetGroupArn: aws.String(targetGroupArn),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out.TargetHealthDescriptions, nil
+}

--- a/aws/ecs/statuser.go
+++ b/aws/ecs/statuser.go
@@ -1,0 +1,169 @@
+package ecs
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/nullstone-io/deployment-sdk/app"
+	"github.com/nullstone-io/deployment-sdk/logging"
+	"github.com/nullstone-io/deployment-sdk/outputs"
+	"gopkg.in/nullstone-io/go-api-client.v0"
+	"time"
+)
+
+var (
+	// Explanations provides plain-english explanations for a task status
+	// See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-lifecycle.html
+	Explanations = map[string]string{
+		"PROVISIONING":   "Creating network resources",
+		"PENDING":        "Provisioning compute resources",
+		"RUNNING":        "Alive",
+		"DEACTIVATING":   "Draining load balancer",
+		"STOPPING":       "Stopping containers",
+		"DEPROVISIONING": "Deleting network resources",
+		"STOPPED":        "Dead",
+		"DELETED":        "Deleted",
+	}
+)
+
+const (
+	ExplanationPullingImage            = "Pulling image"
+	ExplanationRegisteringLoadBalancer = "Registering with load balancer"
+)
+
+type Status struct {
+	Tasks []StatusTask `json:"tasks"`
+}
+
+type StatusTask struct {
+	TaskId            string                `json:"taskId"`
+	StartedAt         *time.Time            `json:"startedAt"`
+	StoppedAt         *time.Time            `json:"stoppedAt"`
+	StoppedReason     string                `json:"stoppedReason"`
+	Status            string                `json:"status"`
+	StatusExplanation string                `json:"statusExplanation"`
+	Health            string                `json:"health"`
+	Containers        []StatusTaskContainer `json:"containers"`
+}
+
+type StatusTaskContainer struct {
+	Name   string                    `json:"name"`
+	Status string                    `json:"status"`
+	Health string                    `json:"health"`
+	Ports  []StatusTaskContainerPort `json:"ports"`
+}
+
+type StatusTaskContainerPort struct {
+	Protocol  string `json:"protocol"`
+	IpAddress string `json:"ipAddress"`
+	// HostPort refers to the external-facing port
+	HostPort int32 `json:"hostPort"`
+	// ContainerPort refers to the port that the container is listening
+	ContainerPort int32 `json:"containerPort"`
+	// HealthStatus refers to the status for an attached load balancer
+	// This is "" if there is no attached load balancer
+	HealthStatus string `json:"status"`
+	// HealthReason refers to the detailed reason for an attached load balancer
+	// This is "" if there is no attached load balancer
+	// See github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types/TargetHealthReasonEnum
+	HealthReason string `json:"reason"`
+}
+
+func NewStatuser(osWriters logging.OsWriters, nsConfig api.Config, appDetails app.Details) (app.Statuser, error) {
+	outs, err := outputs.Retrieve[Outputs](nsConfig, appDetails.Workspace)
+	if err != nil {
+		return nil, err
+	}
+
+	return Statuser{
+		OsWriters: osWriters,
+		Details:   appDetails,
+		Infra:     outs,
+	}, nil
+}
+
+type Statuser struct {
+	OsWriters logging.OsWriters
+	Details   app.Details
+	Infra     Outputs
+}
+
+func (s Statuser) Status(ctx context.Context) (any, error) {
+	st := Status{Tasks: make([]StatusTask, 0)}
+
+	svcHealth, err := GetServiceHealth(ctx, s.Infra)
+	if err != nil {
+		return st, err
+	}
+
+	tasks, err := GetServiceTasks(ctx, s.Infra)
+	if err != nil {
+		return st, err
+	} else if len(tasks) > 0 {
+		return st, nil
+	}
+
+	for _, task := range tasks {
+		st.Tasks = append(st.Tasks, StatusTask{
+			TaskId:            "", // TODO: Get TaskId
+			StartedAt:         task.StartedAt,
+			StoppedAt:         task.StoppedAt,
+			StoppedReason:     aws.ToString(task.StoppedReason),
+			Status:            aws.ToString(task.LastStatus),
+			StatusExplanation: mapTaskStatusToExplanation(task, svcHealth),
+			Health:            string(task.HealthStatus),
+			Containers:        mapTaskContainers(task, svcHealth),
+		})
+	}
+
+	return st, nil
+}
+
+func mapTaskStatusToExplanation(task ecstypes.Task, svcHealth ServiceHealth) string {
+	if task.PullStartedAt != nil && task.PullStoppedAt == nil {
+		return ExplanationPullingImage
+	}
+	if aws.ToString(task.LastStatus) == "ACTIVATING" && len(svcHealth.LoadBalancers) > 0 {
+		return ExplanationRegisteringLoadBalancer
+	}
+
+	if explanation, ok := Explanations[aws.ToString(task.LastStatus)]; ok {
+		return explanation
+	}
+
+	return ""
+}
+
+func mapTaskContainers(task ecstypes.Task, svcHealth ServiceHealth) []StatusTaskContainer {
+	containers := make([]StatusTaskContainer, 0)
+	for _, container := range task.Containers {
+		containers = append(containers, StatusTaskContainer{
+			Name:   aws.ToString(container.Name),
+			Status: aws.ToString(container.LastStatus),
+			Health: string(container.HealthStatus),
+			Ports:  mapContainerPorts(container, svcHealth),
+		})
+	}
+	return containers
+}
+
+func mapContainerPorts(container ecstypes.Container, svcHealth ServiceHealth) []StatusTaskContainerPort {
+	ports := make([]StatusTaskContainerPort, 0)
+	for _, nb := range container.NetworkBindings {
+		port := StatusTaskContainerPort{
+			Protocol:      string(nb.Protocol),
+			IpAddress:     aws.ToString(nb.BindIP),
+			HostPort:      aws.ToInt32(nb.HostPort),
+			ContainerPort: aws.ToInt32(nb.ContainerPort),
+		}
+
+		tgh := svcHealth.FindByTargetId(aws.ToString(nb.BindIP))
+		if tgh != nil && tgh.TargetHealth != nil {
+			port.HealthStatus = string(tgh.TargetHealth.State)
+			port.HealthReason = string(tgh.TargetHealth.Reason)
+		}
+
+		ports = append(ports)
+	}
+	return ports
+}

--- a/aws/ecs/statuser.go
+++ b/aws/ecs/statuser.go
@@ -90,6 +90,10 @@ type Statuser struct {
 
 func (s Statuser) Status(ctx context.Context) (any, error) {
 	st := Status{Tasks: make([]StatusTask, 0)}
+	if s.Infra.ServiceName == "" {
+		// TODO: Add support for Nullstone tasks (apps that aren't long-running)
+		return st, nil
+	}
 
 	svcHealth, err := GetServiceHealth(ctx, s.Infra)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,14 @@ module github.com/nullstone-io/deployment-sdk
 go 1.18
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.17.3
+	github.com/aws/aws-sdk-go-v2 v1.19.0
 	github.com/aws/aws-sdk-go-v2/credentials v1.4.3
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.5.4
 	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.18.4
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.17.8
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.18.11
 	github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.14.9
+	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.19.14
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.23.4
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.27.1
 	github.com/aws/smithy-go v1.13.5
@@ -37,8 +38,8 @@ require (
 	github.com/agext/levenshtein v1.2.1 // indirect
 	github.com/apparentlymart/go-textseg/v12 v12.0.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.3 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.27 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.21 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.35 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -105,8 +105,8 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:l
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go-v2 v1.9.2/go.mod h1:cK/D0BBs0b/oWPIcX/Z/obahJK1TT7IPVjy53i/mX/4=
 github.com/aws/aws-sdk-go-v2 v1.16.7/go.mod h1:6CpKuLXg2w7If3ABZCl/qZ6rEgwtjZTn4eAf4RcEyuw=
-github.com/aws/aws-sdk-go-v2 v1.17.3 h1:shN7NlnVzvDUgPQ+1rLMSxY8OWRNDRYtiqe0p/PgrhY=
-github.com/aws/aws-sdk-go-v2 v1.17.3/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
+github.com/aws/aws-sdk-go-v2 v1.19.0 h1:klAT+y3pGFBU/qVf1uzwttpBbiuozJYWzNLHioyDJ+k=
+github.com/aws/aws-sdk-go-v2 v1.19.0/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.3 h1:S/ZBwevQkr7gv5YxONYpGQxlMFFYSRfz3RMcjsC9Qhk=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.3/go.mod h1:gNsR5CaXKmQSSzrmGxmwmct/r+ZBfbxorAuXYsj/M5Y=
 github.com/aws/aws-sdk-go-v2/config v1.8.3 h1:o5583X4qUfuRrOGOgmOcDgvr5gJVSu57NK08cWAhIDk=
@@ -118,11 +118,11 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.6.0/go.mod h1:gqlclDEZp4aqJOanc
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.5.4 h1:TnU1cY51027j/MQeFy7DIgk1UuzJY+wLFYqXceY/fiE=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.5.4/go.mod h1:Ex7XQmbFmgFHrjUX6TN3mApKW5Hglyga+F7wZHTtYhA=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.14/go.mod h1:kdjrMwHwrC3+FsKhNcCMJ7tUVj/8uSD5CZXeQ4wV6fM=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.27 h1:I3cakv2Uy1vNmmhRQmFptYDxOvBnwCdNwyw63N0RaRU=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.27/go.mod h1:a1/UpzeyBBerajpnP5nGZa9mGzsBn5cOKxm6NWQsvoI=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.35 h1:hMUCiE3Zi5AHrRNGf5j985u0WyqI6r2NULhUfo0N/No=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.35/go.mod h1:ipR5PvpSPqIqL5Mi82BxLnfMkHVbmco8kUwO2xrCi0M=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.8/go.mod h1:ZIV8GYoC6WLBW5KGs+o4rsc65/ozd+eQ0L31XF5VDwk=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.21 h1:5NbbMrIzmUn/TXFqAle6mgrH5m9cOvMLRGL7pnG8tRE=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.21/go.mod h1:+Gxn8jYn5k9ebfHEqlhrMirFjSW0v0C9fI+KN5vk2kE=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.29 h1:yOpYx+FTBdpk/g+sBU6Cb1H0U/TLEcYYp66mYqsPpcc=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.29/go.mod h1:M/eUABlDbw2uVrdAn+UsI6M727qp2fxkp8K0ejcBDUY=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.2.4 h1:leSJ6vCqtPpTmBIgE7044B1wql1E4n//McF+mEgNrYg=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.2.4/go.mod h1:ZcBrrI3zBKlhGFNYWvju0I3TR93I7YIgAfy82Fh4lcQ=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.5 h1:tEEHn+PGAxRVqMPEhtU8oCSW/1Ge3zP5nUgPrGQNUPs=
@@ -135,6 +135,8 @@ github.com/aws/aws-sdk-go-v2/service/ecs v1.18.11 h1:MWJBTtfIwBJJn7AMYiyvc2g62HU
 github.com/aws/aws-sdk-go-v2/service/ecs v1.18.11/go.mod h1:3+9Tsuq6J9nezo2AO9UYzUVgZ72W21Ryh0d+DJRCzys=
 github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.14.9 h1:78ENf49ag/glp/z+6NR2lEoXWsnlHZUK1JLs5eNSm+M=
 github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.14.9/go.mod h1:BY71CNhZ9kzmpcDwKsPzyf1xt5PADO/+4Wmnopgyv6o=
+github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.19.14 h1:ekfFZUYzAqzBYhh1bwIen4SNLIn4KiMNDWyRmfbp62I=
+github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.19.14/go.mod h1:0eT2aeVd4MnWmyT935I2MTwP5xT7cFVteV02BgJ/F+E=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.3.0/go.mod h1:v8ygadNyATSm6elwJ/4gzJwcFhri9RqS8skgHKiwXPU=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.3 h1:4n4KCtv5SUoT5Er5XV41huuzrCqepxlW3SDI9qHQebc=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.3/go.mod h1:gkb2qADY+OHaGLKNTYxMaQNacfeyQpZ4csDTQMeFmcw=


### PR DESCRIPTION
This adds another Provider queryable `Statuser` that reports the status of an app.

This PR only adds support for long-running ECS/Fargate apps. (Other apps to be added later)