### PR TITLE
B1796 nil pointer

### DIFF
--- a/app/providers.go
+++ b/app/providers.go
@@ -42,7 +42,7 @@ func (s Providers) FindStatuser(osWriters logging.OsWriters, nsConfig api.Config
 
 func (s Providers) FindLogStreamer(osWriters logging.OsWriters, nsConfig api.Config, appDetails Details) (LogStreamer, error) {
 	factory := s.FindFactory(*appDetails.Module)
-	if factory == nil || factory.NewStatuser == nil {
+	if factory == nil || factory.NewLogStreamer == nil {
 		return nil, nil
 	}
 	return factory.NewLogStreamer(osWriters, nsConfig, appDetails)

--- a/aws/cloudwatch/log_streamer.go
+++ b/aws/cloudwatch/log_streamer.go
@@ -56,7 +56,6 @@ func (l LogStreamer) Stream(ctx context.Context, options app.LogStreamOptions) e
 	}
 	logger.Println("Querying the following log groups:")
 	logger.Printf("\t%s\n", strings.Join(logGroupNames, "\n\t"))
-	logger.Println()
 
 	g, ctx := errgroup.WithContext(ctx)
 	for _, logGroupName := range logGroupNames {


### PR DESCRIPTION
This PR fixes the providers factory to do the correct check when trying to create a new log streamer. It looks like this was copy pasted and missed.