### PR TITLE
F1815 deploy version

### DIFF
--- a/app/provider.go
+++ b/app/provider.go
@@ -24,6 +24,7 @@ type NewLogStreamerFunc func(osWriters logging.OsWriters, source outputs.Retriev
 
 type Pusher interface {
 	Push(ctx context.Context, source, version string) error
+	CalculateVersion(ctx context.Context, commitSha string) (string, error)
 }
 
 type Deployer interface {

--- a/app/provider.go
+++ b/app/provider.go
@@ -24,7 +24,7 @@ type NewLogStreamerFunc func(osWriters logging.OsWriters, source outputs.Retriev
 
 type Pusher interface {
 	Push(ctx context.Context, source, version string) error
-	CalculateVersion(ctx context.Context, commitSha string) (string, error)
+	ListArtifacts(ctx context.Context) ([]string, error)
 }
 
 type Deployer interface {

--- a/app/provider.go
+++ b/app/provider.go
@@ -24,7 +24,7 @@ type NewLogStreamerFunc func(osWriters logging.OsWriters, source outputs.Retriev
 
 type Pusher interface {
 	Push(ctx context.Context, source, version string) error
-	ListArtifacts(ctx context.Context) ([]string, error)
+	ListArtifactVersions(ctx context.Context) ([]string, error)
 }
 
 type Deployer interface {

--- a/aws/beanstalk/pusher.go
+++ b/aws/beanstalk/pusher.go
@@ -52,6 +52,6 @@ func (p Pusher) Push(ctx context.Context, source, version string) error {
 	return nil
 }
 
-func (p Pusher) CalculateVersion(ctx context.Context, commitSha string) (string, error) {
-	return p.zipPusher.CalculateVersion(ctx, commitSha)
+func (p Pusher) ListArtifacts(ctx context.Context) ([]string, error) {
+	return p.zipPusher.ListArtifacts(ctx)
 }

--- a/aws/beanstalk/pusher.go
+++ b/aws/beanstalk/pusher.go
@@ -51,3 +51,7 @@ func (p Pusher) Push(ctx context.Context, source, version string) error {
 
 	return nil
 }
+
+func (p Pusher) CalculateVersion(ctx context.Context, commitSha string) (string, error) {
+	return p.zipPusher.CalculateVersion(ctx, commitSha)
+}

--- a/aws/beanstalk/pusher.go
+++ b/aws/beanstalk/pusher.go
@@ -52,6 +52,6 @@ func (p Pusher) Push(ctx context.Context, source, version string) error {
 	return nil
 }
 
-func (p Pusher) ListArtifacts(ctx context.Context) ([]string, error) {
-	return p.zipPusher.ListArtifacts(ctx)
+func (p Pusher) ListArtifactVersions(ctx context.Context) ([]string, error) {
+	return p.zipPusher.ListArtifactVersions(ctx)
 }

--- a/aws/ecr/pusher.go
+++ b/aws/ecr/pusher.go
@@ -84,10 +84,6 @@ func (p Pusher) Push(ctx context.Context, source, version string) error {
 	return nil
 }
 
-func (p Pusher) CalculateVersion(ctx context.Context, commitSha string) (string, error) {
-	return commitSha, nil
-}
-
 func (p Pusher) ListArtifacts(ctx context.Context) ([]string, error) {
 	targetAuth, err := p.getEcrLoginAuth(ctx)
 	if err != nil {

--- a/aws/ecr/pusher.go
+++ b/aws/ecr/pusher.go
@@ -88,6 +88,19 @@ func (p Pusher) CalculateVersion(ctx context.Context, commitSha string) (string,
 	return commitSha, nil
 }
 
+func (p Pusher) ListArtifacts(ctx context.Context) ([]string, error) {
+	targetAuth, err := p.getEcrLoginAuth(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving image registry credentials: %w", err)
+	}
+
+	tags, err := docker.ListRemoteTags(ctx, p.Infra.ImageRepoUrl, targetAuth)
+	if err != nil {
+		return nil, fmt.Errorf("error listing remote tags: %w", err)
+	}
+	return tags, nil
+}
+
 func (p Pusher) validate(targetUrl docker.ImageUrl) error {
 	if targetUrl.String() == "" {
 		return fmt.Errorf("cannot push if 'image_repo_url' module output is missing")

--- a/aws/ecr/pusher.go
+++ b/aws/ecr/pusher.go
@@ -13,6 +13,8 @@ import (
 	"github.com/nullstone-io/deployment-sdk/docker"
 	"github.com/nullstone-io/deployment-sdk/logging"
 	"github.com/nullstone-io/deployment-sdk/outputs"
+	"gopkg.in/nullstone-io/go-api-client.v0"
+	"log"
 	"strings"
 	"time"
 )
@@ -61,6 +63,14 @@ func (p Pusher) Push(ctx context.Context, source, version string) error {
 		return fmt.Errorf("error creating docker client: %w", err)
 	}
 
+	list, err := dockerCli.Client().ImageList(ctx, dockertypes.ImageListOptions{})
+	if err != nil {
+		return fmt.Errorf("error listing images: %w", err)
+	}
+	for _, img := range list {
+		log.Printf("Image: %#v\n", img)
+	}
+
 	fmt.Fprintf(stdout, "Retagging %s => %s\n", sourceUrl.String(), targetUrl.String())
 	if err := dockerCli.Client().ImageTag(ctx, sourceUrl.String(), targetUrl.String()); err != nil {
 		return fmt.Errorf("error retagging image: %w", err)
@@ -72,6 +82,10 @@ func (p Pusher) Push(ctx context.Context, source, version string) error {
 	}
 
 	return nil
+}
+
+func (p Pusher) CalculateVersion(ctx context.Context, commitSha string) (string, error) {
+	return commitSha, nil
 }
 
 func (p Pusher) validate(targetUrl docker.ImageUrl) error {

--- a/aws/ecr/pusher.go
+++ b/aws/ecr/pusher.go
@@ -13,7 +13,6 @@ import (
 	"github.com/nullstone-io/deployment-sdk/docker"
 	"github.com/nullstone-io/deployment-sdk/logging"
 	"github.com/nullstone-io/deployment-sdk/outputs"
-	"log"
 	"strings"
 	"time"
 )
@@ -60,14 +59,6 @@ func (p Pusher) Push(ctx context.Context, source, version string) error {
 	dockerCli, err := docker.DiscoverDockerCli(p.OsWriters)
 	if err != nil {
 		return fmt.Errorf("error creating docker client: %w", err)
-	}
-
-	list, err := dockerCli.Client().ImageList(ctx, dockertypes.ImageListOptions{})
-	if err != nil {
-		return fmt.Errorf("error listing images: %w", err)
-	}
-	for _, img := range list {
-		log.Printf("Image: %#v\n", img)
 	}
 
 	fmt.Fprintf(stdout, "Retagging %s => %s\n", sourceUrl.String(), targetUrl.String())

--- a/aws/ecr/pusher.go
+++ b/aws/ecr/pusher.go
@@ -13,7 +13,6 @@ import (
 	"github.com/nullstone-io/deployment-sdk/docker"
 	"github.com/nullstone-io/deployment-sdk/logging"
 	"github.com/nullstone-io/deployment-sdk/outputs"
-	"gopkg.in/nullstone-io/go-api-client.v0"
 	"log"
 	"strings"
 	"time"

--- a/aws/ecr/pusher.go
+++ b/aws/ecr/pusher.go
@@ -74,7 +74,7 @@ func (p Pusher) Push(ctx context.Context, source, version string) error {
 	return nil
 }
 
-func (p Pusher) ListArtifacts(ctx context.Context) ([]string, error) {
+func (p Pusher) ListArtifactVersions(ctx context.Context) ([]string, error) {
 	targetAuth, err := p.getEcrLoginAuth(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving image registry credentials: %w", err)

--- a/aws/s3/dir_pusher.go
+++ b/aws/s3/dir_pusher.go
@@ -7,6 +7,8 @@ import (
 	"github.com/nullstone-io/deployment-sdk/artifacts"
 	"github.com/nullstone-io/deployment-sdk/logging"
 	"github.com/nullstone-io/deployment-sdk/outputs"
+	"gopkg.in/nullstone-io/go-api-client.v0"
+	"strings"
 )
 
 func NewDirPusher(osWriters logging.OsWriters, source outputs.RetrieverSource, appDetails app.Details) (app.Pusher, error) {
@@ -51,5 +53,23 @@ func (p DirPusher) Push(ctx context.Context, source, version string) error {
 }
 
 func (p DirPusher) ListArtifacts(ctx context.Context) ([]string, error) {
-	return []string{}, nil
+	dirs, err := ListDirs(ctx, p.Infra)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]string, 0)
+	if before, after, found := strings.Cut(p.Infra.ArtifactsKeyTemplate, KeyTemplateAppVersion); found {
+		for _, dir := range dirs {
+			cur := strings.TrimPrefix(dir, before)
+			cur = strings.TrimSuffix(cur, after)
+			results = append(results, cur)
+		}
+	} else {
+		for _, dir := range dirs {
+			results = append(results, dir)
+		}
+	}
+
+	return results, nil
 }

--- a/aws/s3/dir_pusher.go
+++ b/aws/s3/dir_pusher.go
@@ -50,6 +50,6 @@ func (p DirPusher) Push(ctx context.Context, source, version string) error {
 	return nil
 }
 
-func (p DirPusher) CalculateVersion(ctx context.Context, commitSha string) (string, error) {
-	return commitSha, nil
+func (p DirPusher) ListArtifacts(ctx context.Context) ([]string, error) {
+	return []string{}, nil
 }

--- a/aws/s3/dir_pusher.go
+++ b/aws/s3/dir_pusher.go
@@ -49,3 +49,7 @@ func (p DirPusher) Push(ctx context.Context, source, version string) error {
 
 	return nil
 }
+
+func (p DirPusher) CalculateVersion(ctx context.Context, commitSha string) (string, error) {
+	return commitSha, nil
+}

--- a/aws/s3/dir_pusher.go
+++ b/aws/s3/dir_pusher.go
@@ -7,7 +7,6 @@ import (
 	"github.com/nullstone-io/deployment-sdk/artifacts"
 	"github.com/nullstone-io/deployment-sdk/logging"
 	"github.com/nullstone-io/deployment-sdk/outputs"
-	"gopkg.in/nullstone-io/go-api-client.v0"
 	"strings"
 )
 

--- a/aws/s3/dir_pusher.go
+++ b/aws/s3/dir_pusher.go
@@ -51,7 +51,7 @@ func (p DirPusher) Push(ctx context.Context, source, version string) error {
 	return nil
 }
 
-func (p DirPusher) ListArtifacts(ctx context.Context) ([]string, error) {
+func (p DirPusher) ListArtifactVersions(ctx context.Context) ([]string, error) {
 	dirs, err := ListDirs(ctx, p.Infra)
 	if err != nil {
 		return nil, err

--- a/aws/s3/list_dirs.go
+++ b/aws/s3/list_dirs.go
@@ -1,0 +1,41 @@
+package s3
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	nsaws "github.com/nullstone-io/deployment-sdk/aws"
+)
+
+// ListDirs queries s3 buckets for a listing of keys to determine root directories
+// S3 doesn't have the concept of directories;
+// this simulates by finding a common set of prefixes preceding a `/` in the object key
+func ListDirs(ctx context.Context, infra Outputs) ([]string, error) {
+	s3Client := s3.NewFromConfig(nsaws.NewConfig(infra.Deployer, infra.Region))
+
+	visited := map[string]bool{}
+	result := make([]string, 0)
+
+	input := &s3.ListObjectsV2Input{
+		Bucket:    aws.String(infra.ArtifactsBucketName),
+		Delimiter: aws.String("/"),
+	}
+	paginator := s3.NewListObjectsV2Paginator(s3Client, input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("error listing bucket objects: %w", err)
+		}
+
+		for _, prefix := range page.CommonPrefixes {
+			dir := *prefix.Prefix
+			if _, ok := visited[dir]; !ok {
+				visited[dir] = true
+				result = append(result, dir)
+			}
+		}
+	}
+
+	return result, nil
+}

--- a/aws/s3/list_objects.go
+++ b/aws/s3/list_objects.go
@@ -1,0 +1,34 @@
+package s3
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	nsaws "github.com/nullstone-io/deployment-sdk/aws"
+)
+
+func ListObjects(ctx context.Context, infra Outputs, prefix string) ([]types.Object, error) {
+	s3Client := s3.NewFromConfig(nsaws.NewConfig(infra.Deployer, infra.Region))
+
+	result := make([]types.Object, 0)
+
+	input := &s3.ListObjectsV2Input{Bucket: aws.String(infra.ArtifactsBucketName)}
+	if prefix != "" {
+		input.Prefix = aws.String(prefix)
+	}
+	paginator := s3.NewListObjectsV2Paginator(s3Client, input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("error listing bucket objects: %w", err)
+		}
+
+		for _, object := range page.Contents {
+			result = append(result, object)
+		}
+	}
+
+	return result, nil
+}

--- a/aws/s3/zip_pusher.go
+++ b/aws/s3/zip_pusher.go
@@ -52,10 +52,6 @@ func (p ZipPusher) Push(ctx context.Context, source, version string) error {
 	return nil
 }
 
-func (p ZipPusher) CalculateVersion(ctx context.Context, commitSha string) (string, error) {
-	// pull all zip filenames from the s3 bucket
-	// find the latest zip filename that contains the commitSha
-	// extract the version from the filename and return
-
-	return commitSha, nil
+func (p ZipPusher) ListArtifacts(ctx context.Context) ([]string, error) {
+	return []string{}, nil
 }

--- a/aws/s3/zip_pusher.go
+++ b/aws/s3/zip_pusher.go
@@ -51,3 +51,11 @@ func (p ZipPusher) Push(ctx context.Context, source, version string) error {
 	fmt.Fprintln(stdout, "Upload complete")
 	return nil
 }
+
+func (p ZipPusher) CalculateVersion(ctx context.Context, commitSha string) (string, error) {
+	// pull all zip filenames from the s3 bucket
+	// find the latest zip filename that contains the commitSha
+	// extract the version from the filename and return
+
+	return commitSha, nil
+}

--- a/aws/s3/zip_pusher.go
+++ b/aws/s3/zip_pusher.go
@@ -53,7 +53,7 @@ func (p ZipPusher) Push(ctx context.Context, source, version string) error {
 	return nil
 }
 
-func (p ZipPusher) ListArtifacts(ctx context.Context) ([]string, error) {
+func (p ZipPusher) ListArtifactVersions(ctx context.Context) ([]string, error) {
 	results := make([]string, 0)
 	if before, after, found := strings.Cut(p.Infra.ArtifactsKeyTemplate, KeyTemplateAppVersion); found {
 		objects, err := ListObjects(ctx, p.Infra, before)

--- a/docker/authed_transport.go
+++ b/docker/authed_transport.go
@@ -1,0 +1,31 @@
+package docker
+
+import (
+	"encoding/base64"
+	"fmt"
+	"github.com/docker/docker/api/types"
+	"net/http"
+)
+
+type AuthedTransport struct {
+	Transport http.RoundTripper
+	Auth      types.AuthConfig
+}
+
+func (t AuthedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if bearer := t.Auth.RegistryToken; bearer != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", bearer))
+	} else if user, pass := t.Auth.Username, t.Auth.Password; user != "" && pass != "" {
+		delimited := fmt.Sprintf("%s:%s", user, pass)
+		encoded := base64.StdEncoding.EncodeToString([]byte(delimited))
+		req.Header.Set("Authorization", fmt.Sprintf("Basic %s", encoded))
+	} else if token := t.Auth.Auth; token != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Basic %s", token))
+	}
+
+	if t.Transport == nil {
+		return http.DefaultTransport.RoundTrip(req)
+	} else {
+		return t.Transport.RoundTrip(req)
+	}
+}

--- a/docker/list_remote_tags.go
+++ b/docker/list_remote_tags.go
@@ -1,0 +1,15 @@
+package docker
+
+import (
+	"context"
+	"github.com/docker/docker/api/types"
+)
+
+type ListRemoteTagsResponse struct {
+	Name string   `json:"name"`
+	Tags []string `json:"tags"`
+}
+
+func ListRemoteTags(ctx context.Context, targetUrl ImageUrl, targetAuth types.AuthConfig) ([]string, error) {
+	return []string{}, nil
+}

--- a/docker/list_remote_tags.go
+++ b/docker/list_remote_tags.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/docker/docker/api/types"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -32,6 +33,14 @@ func ListRemoteTags(ctx context.Context, targetUrl ImageUrl, targetAuth types.Au
 	}
 	if res.Body != nil {
 		defer res.Body.Close()
+	}
+
+	if res.StatusCode >= 400 {
+		raw, err := io.ReadAll(res.Body)
+		if err != nil {
+			return nil, fmt.Errorf("error reading error (status code = %d) response: %w", res.StatusCode, err)
+		}
+		return nil, fmt.Errorf("error response (status code = %d): %s", res.StatusCode, string(raw))
 	}
 
 	decoder := json.NewDecoder(res.Body)

--- a/docker/list_remote_tags.go
+++ b/docker/list_remote_tags.go
@@ -2,7 +2,11 @@ package docker
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"github.com/docker/docker/api/types"
+	"net/http"
+	"net/url"
 )
 
 type ListRemoteTagsResponse struct {
@@ -11,5 +15,30 @@ type ListRemoteTagsResponse struct {
 }
 
 func ListRemoteTags(ctx context.Context, targetUrl ImageUrl, targetAuth types.AuthConfig) ([]string, error) {
-	return []string{}, nil
+	client := &http.Client{Transport: AuthedTransport{Auth: targetAuth}}
+	u := url.URL{
+		Scheme: targetUrl.Scheme(),
+		Host:   targetUrl.Registry,
+		Path:   fmt.Sprintf("/v2/%s/tags/list", targetUrl.RepoName()),
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating list remote tags request: %w", err)
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error getting list remote tags response: %w", err)
+	}
+	if res.Body != nil {
+		defer res.Body.Close()
+	}
+
+	decoder := json.NewDecoder(res.Body)
+	var result ListRemoteTagsResponse
+	if err := decoder.Decode(&result); err != nil {
+		return nil, fmt.Errorf("error reading json response: %w", err)
+	}
+
+	return result.Tags, nil
 }

--- a/docker/manual-test/main.go
+++ b/docker/manual-test/main.go
@@ -28,7 +28,7 @@ func main() {
 		},
 	}
 
-	tags, err := pusher.ListArtifacts(ctx)
+	tags, err := pusher.ListArtifactVersions(ctx)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/docker/manual-test/main.go
+++ b/docker/manual-test/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/nullstone-io/deployment-sdk/aws"
+	"github.com/nullstone-io/deployment-sdk/aws/ecr"
+	"github.com/nullstone-io/deployment-sdk/docker"
+	"github.com/nullstone-io/deployment-sdk/logging"
+	"log"
+	"os"
+)
+
+func main() {
+	ctx := context.Background()
+
+	pusher := ecr.Pusher{
+		OsWriters: logging.StandardOsWriters{},
+		Infra: ecr.Outputs{
+			Region:       "us-east-1",
+			ImageRepoUrl: docker.ParseImageUrl("820877947822.dkr.ecr.us-east-1.amazonaws.com/api-gateway-bufms"),
+			ImagePusher: nsaws.User{
+				Name:            "image-pusher-api-gateway-bufms",
+				AccessKeyId:     os.Getenv("AWS_ACCESS_KEY_ID"),
+				SecretAccessKey: os.Getenv("AWS_SECRET_ACCESS_KEY"),
+			},
+		},
+	}
+
+	tags, err := pusher.ListArtifacts(ctx)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	raw, err := json.MarshalIndent(tags, "", "  ")
+	fmt.Println(string(raw))
+}

--- a/gcp/gcr/pusher.go
+++ b/gcp/gcr/pusher.go
@@ -72,6 +72,10 @@ func (p Pusher) Push(ctx context.Context, source, version string) error {
 	return nil
 }
 
+func (p Pusher) CalculateVersion(ctx context.Context, commitSha string) (string, error) {
+	return commitSha, nil
+}
+
 func (p Pusher) validate(targetUrl docker.ImageUrl) error {
 	if targetUrl.String() == "" {
 		return fmt.Errorf("cannot push if 'image_repo_url' module output is missing")

--- a/gcp/gcr/pusher.go
+++ b/gcp/gcr/pusher.go
@@ -72,7 +72,7 @@ func (p Pusher) Push(ctx context.Context, source, version string) error {
 	return nil
 }
 
-func (p Pusher) ListArtifacts(ctx context.Context) ([]string, error) {
+func (p Pusher) ListArtifactVersions(ctx context.Context) ([]string, error) {
 	targetAuth, err := p.getGcrLoginAuth(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving image registry credentials: %w", err)

--- a/gcp/gcr/pusher.go
+++ b/gcp/gcr/pusher.go
@@ -72,8 +72,17 @@ func (p Pusher) Push(ctx context.Context, source, version string) error {
 	return nil
 }
 
-func (p Pusher) CalculateVersion(ctx context.Context, commitSha string) (string, error) {
-	return commitSha, nil
+func (p Pusher) ListArtifacts(ctx context.Context) ([]string, error) {
+	targetAuth, err := p.getGcrLoginAuth(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving image registry credentials: %w", err)
+	}
+
+	tags, err := docker.ListRemoteTags(ctx, p.Infra.ImageRepoUrl, targetAuth)
+	if err != nil {
+		return nil, fmt.Errorf("error listing remote tags: %w", err)
+	}
+	return tags, nil
 }
 
 func (p Pusher) validate(targetUrl docker.ImageUrl) error {


### PR DESCRIPTION
This PR adds support for "Pushers" to be able to list their artifacts. This feature allows us to determine if artifacts already exists for a particular commit sha. This is used in the nullstone CLI during push, deploy, and launch commands.