### PR TITLE
Paging through results when listing docker remote tags

### DIFF
--- a/docker/list_remote_tags.go
+++ b/docker/list_remote_tags.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/docker/docker/api/types"
+	"github.com/tomnomnom/linkheader"
 	"io"
 	"net/http"
 	"net/url"
@@ -16,20 +17,38 @@ type ListRemoteTagsResponse struct {
 }
 
 func ListRemoteTags(ctx context.Context, targetUrl ImageUrl, targetAuth types.AuthConfig) ([]string, error) {
-	client := &http.Client{Transport: AuthedTransport{Auth: targetAuth}}
-	u := url.URL{
+	reqUrl := (&url.URL{
 		Scheme: targetUrl.Scheme(),
 		Host:   targetUrl.Registry,
 		Path:   fmt.Sprintf("/v2/%s/tags/list", targetUrl.RepoName()),
+	}).String()
+
+	allTags := make([]string, 0)
+	for {
+		pageTags, res, err := doListRemoteTags(ctx, reqUrl, targetAuth)
+		if err != nil {
+			return nil, err
+		} else if pageTags != nil {
+			allTags = append(allTags, pageTags...)
+		}
+
+		// Continue listing tags on the next page if the response contains a "next page"
+		if reqUrl = getNextPageUrl(res); reqUrl == "" {
+			return allTags, nil
+		}
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+}
+
+func doListRemoteTags(ctx context.Context, reqUrl string, targetAuth types.AuthConfig) ([]string, *http.Response, error) {
+	client := &http.Client{Transport: AuthedTransport{Auth: targetAuth}}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqUrl, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error creating list remote tags request: %w", err)
+		return nil, nil, fmt.Errorf("error creating list remote tags request: %w", err)
 	}
 
 	res, err := client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("error getting list remote tags response: %w", err)
+		return nil, nil, fmt.Errorf("error getting list remote tags response: %w", err)
 	}
 	if res.Body != nil {
 		defer res.Body.Close()
@@ -38,16 +57,29 @@ func ListRemoteTags(ctx context.Context, targetUrl ImageUrl, targetAuth types.Au
 	if res.StatusCode >= 400 {
 		raw, err := io.ReadAll(res.Body)
 		if err != nil {
-			return nil, fmt.Errorf("error reading error (status code = %d) response: %w", res.StatusCode, err)
+			return nil, res, fmt.Errorf("error reading error (status code = %d) response: %w", res.StatusCode, err)
 		}
-		return nil, fmt.Errorf("error response (status code = %d): %s", res.StatusCode, string(raw))
+		return nil, res, fmt.Errorf("error response (status code = %d): %s", res.StatusCode, string(raw))
 	}
 
 	decoder := json.NewDecoder(res.Body)
 	var result ListRemoteTagsResponse
 	if err := decoder.Decode(&result); err != nil {
-		return nil, fmt.Errorf("error reading json response: %w", err)
+		return nil, res, fmt.Errorf("error reading json response: %w", err)
 	}
 
-	return result.Tags, nil
+	return result.Tags, res, nil
+}
+
+func getNextPageUrl(res *http.Response) string {
+	val := res.Header.Get("Link")
+	if val == "" {
+		return ""
+	}
+	for _, link := range linkheader.Parse(val) {
+		if link.Rel == "next" {
+			return link.URL
+		}
+	}
+	return ""
 }

--- a/docker/manual-test/main.go
+++ b/docker/manual-test/main.go
@@ -15,13 +15,17 @@ import (
 func main() {
 	ctx := context.Background()
 
+	accountId := "" // AWS Account ID
+	region := "us-east-1"
+	repoName := "" // ECR image repo name
+	imageUrl := docker.ParseImageUrl(fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", accountId, region, repoName))
+
 	pusher := ecr.Pusher{
 		OsWriters: logging.StandardOsWriters{},
 		Infra: ecr.Outputs{
-			Region:       "us-east-1",
-			ImageRepoUrl: docker.ParseImageUrl("820877947822.dkr.ecr.us-east-1.amazonaws.com/api-gateway-bufms"),
+			Region:       region,
+			ImageRepoUrl: imageUrl,
 			ImagePusher: nsaws.User{
-				Name:            "image-pusher-api-gateway-bufms",
 				AccessKeyId:     os.Getenv("AWS_ACCESS_KEY_ID"),
 				SecretAccessKey: os.Getenv("AWS_SECRET_ACCESS_KEY"),
 			},

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/sethvargo/go-retry v0.2.3
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.1
+	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80
 	github.com/vmihailenco/tagparser v0.1.2
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f

--- a/go.sum
+++ b/go.sum
@@ -924,6 +924,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tmccombs/hcl2json v0.3.2-0.20201111174327-c96737926b76/go.mod h1:ljY0/prd2IFUF3cagQjV3cpPEEQKzqyGqnKI7m5DBVY=
 github.com/tmccombs/hcl2json v0.3.4 h1:pYzRaHVTJu6TfFumACORClRtsK431eeuv7WjNNLjT90=
 github.com/tmccombs/hcl2json v0.3.4/go.mod h1:l3Aq9eUyhC+0v26BH08BZHeyWEtOYcFtbu2i5Ryywig=
+github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
+github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=


### PR DESCRIPTION
This fixes an issue where `ListArtifactVersions` is used to find an existing artifact, but it cannot be found.
This happens because the previous code did not page through all results and ECR caps the first page to 100 tags.
For our initial test cases, we used image repositories that had > 100 tags, but it's still possible that the correct tag was listed in the first page.

I confirmed this behavior and the appropriate fix using the manual test utility `docker/manual-test/main.go`:
```
# current code
go run manual-test/main.go | jq -r '. | length'
100

# after fix
go run manual-test/main.go | jq -r '. | length'
116
```