### PR TITLE
B1908 batch job description revision fix

### DIFF
--- a/aws/batch/create_job_definition.go
+++ b/aws/batch/create_job_definition.go
@@ -9,7 +9,7 @@ import (
 	nsaws "github.com/nullstone-io/deployment-sdk/aws"
 )
 
-func UpdateJobDefinition(ctx context.Context, infra Outputs, jobDefinition *batchtypes.JobDefinition, previousJobDefArn string) (*string, error) {
+func CreateJobDefinition(ctx context.Context, infra Outputs, jobDefinition *batchtypes.JobDefinition) (*string, *int32, error) {
 	client := batch.NewFromConfig(nsaws.NewConfig(infra.Deployer, infra.Region))
 
 	input := &batch.RegisterJobDefinitionInput{
@@ -29,15 +29,8 @@ func UpdateJobDefinition(ctx context.Context, infra Outputs, jobDefinition *batc
 	}
 	out, err := client.RegisterJobDefinition(ctx, input)
 	if err != nil {
-		return nil, fmt.Errorf("unable to register job definition: %w", err)
+		return nil, nil, fmt.Errorf("unable to register job definition: %w", err)
 	}
 
-	_, err = client.DeregisterJobDefinition(ctx, &batch.DeregisterJobDefinitionInput{
-		JobDefinition: &previousJobDefArn,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("unable to deregister job definition: %w", err)
-	}
-
-	return out.JobDefinitionArn, nil
+	return out.JobDefinitionArn, out.Revision, nil
 }

--- a/aws/batch/deregister_job_definitions.go
+++ b/aws/batch/deregister_job_definitions.go
@@ -1,0 +1,25 @@
+package batch
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/service/batch"
+	batchtypes "github.com/aws/aws-sdk-go-v2/service/batch/types"
+	nsaws "github.com/nullstone-io/deployment-sdk/aws"
+)
+
+func DeregisterJobDefinitions(ctx context.Context, infra Outputs, jobDefs []batchtypes.JobDefinition) ([]int32, error) {
+	client := batch.NewFromConfig(nsaws.NewConfig(infra.Deployer, infra.Region))
+
+	deregisteredRevisions := make([]int32, 0, len(jobDefs))
+	for _, jobDef := range jobDefs {
+		_, err := client.DeregisterJobDefinition(ctx, &batch.DeregisterJobDefinitionInput{
+			JobDefinition: jobDef.JobDefinitionArn,
+		})
+		if err != nil {
+			return deregisteredRevisions, fmt.Errorf("error deregistering job definition: %w", err)
+		}
+		deregisteredRevisions = append(deregisteredRevisions, *jobDef.Revision)
+	}
+	return deregisteredRevisions, nil
+}

--- a/aws/batch/get_job_definition.go
+++ b/aws/batch/get_job_definition.go
@@ -8,7 +8,7 @@ import (
 	nsaws "github.com/nullstone-io/deployment-sdk/aws"
 )
 
-func GetJobDefinition(ctx context.Context, infra Outputs) (*batchtypes.JobDefinition, error) {
+func GetJobDefinition(ctx context.Context, infra Outputs) (*batchtypes.JobDefinition, []batchtypes.JobDefinition, error) {
 	client := batch.NewFromConfig(nsaws.NewConfig(infra.Deployer, infra.Region))
 	active := "ACTIVE"
 	lookup := &batch.DescribeJobDefinitionsInput{
@@ -17,19 +17,20 @@ func GetJobDefinition(ctx context.Context, infra Outputs) (*batchtypes.JobDefini
 	}
 	jobDefs, err := client.DescribeJobDefinitions(ctx, lookup)
 	if err != nil {
-		return nil, fmt.Errorf("error getting job definition: %w", err)
+		return nil, nil, fmt.Errorf("error getting job definition: %w", err)
 	}
 	if len(jobDefs.JobDefinitions) == 0 {
-		return nil, fmt.Errorf("job definition named %q not found", infra.JobDefinitionName)
+		return nil, nil, fmt.Errorf("job definition named %q not found", infra.JobDefinitionName)
 	}
-	return getLatestJobDefinition(jobDefs.JobDefinitions), nil
+	return getLatestJobDefinition(jobDefs.JobDefinitions), jobDefs.JobDefinitions, nil
 }
 
 func getLatestJobDefinition(defs []batchtypes.JobDefinition) *batchtypes.JobDefinition {
 	var latest *batchtypes.JobDefinition
 	for _, def := range defs {
 		if latest == nil || (def.Revision != nil && *def.Revision > *latest.Revision) {
-			latest = &def
+			newLatest := def
+			latest = &newLatest
 		}
 	}
 	return latest

--- a/aws/batch/get_job_definition_test.go
+++ b/aws/batch/get_job_definition_test.go
@@ -10,6 +10,14 @@ func TestGetJobDefinition(t *testing.T) {
 	one := int32(1)
 	two := int32(2)
 	three := int32(3)
+	four := int32(4)
+	five := int32(5)
+	six := int32(6)
+	seven := int32(7)
+	eight := int32(8)
+	nine := int32(9)
+	ten := int32(10)
+	eleven := int32(11)
 
 	tests := []struct {
 		name string
@@ -31,11 +39,19 @@ func TestGetJobDefinition(t *testing.T) {
 		{
 			name: "multiple definitions",
 			defs: []batchtypes.JobDefinition{
+				{Revision: &eight},
+				{Revision: &nine},
+				{Revision: &ten},
 				{Revision: &one},
 				{Revision: &three},
 				{Revision: &two},
+				{Revision: &eleven},
+				{Revision: &four},
+				{Revision: &five},
+				{Revision: &six},
+				{Revision: &seven},
 			},
-			want: &three,
+			want: &eleven,
 		},
 	}
 


### PR DESCRIPTION
This PR updates the deployment process for AWS batch jobs in 3 ways:

1. The logic for selecting the most recent revision from the list of active revisions was wrong. This updates the test and fixes the logic.
2. Instead of just deregistering the most recent active revision, this now deregisters all prior active revisions. The extra active revisions are added when infra changes are made via terraform.
3. Added better logging so you can tell what the deployment is actually doing.
