### PR TITLE
Accepting WorkspaceConfig for outputs Retriever

### DIFF
--- a/app/details.go
+++ b/app/details.go
@@ -3,8 +3,9 @@ package app
 import "gopkg.in/nullstone-io/go-api-client.v0/types"
 
 type Details struct {
-	App       *types.Application
-	Env       *types.Environment
-	Workspace *types.Workspace
-	Module    *types.Module
+	App             *types.Application     `json:"app"`
+	Env             *types.Environment     `json:"env"`
+	Workspace       *types.Workspace       `json:"workspace"`
+	WorkspaceConfig *types.WorkspaceConfig `json:"workspaceConfig"`
+	Module          *types.Module          `json:"module"`
 }

--- a/aws/batch/deployer.go
+++ b/aws/batch/deployer.go
@@ -10,7 +10,7 @@ import (
 )
 
 func NewDeployer(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, appDetails app.Details) (app.Deployer, error) {
-	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace)
+	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace, appDetails.WorkspaceConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/beanstalk/deploy_status_getter.go
+++ b/aws/beanstalk/deploy_status_getter.go
@@ -10,7 +10,7 @@ import (
 )
 
 func NewDeployStatusGetter(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, appDetails app.Details) (app.DeployStatusGetter, error) {
-	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace)
+	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace, appDetails.WorkspaceConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/beanstalk/deployer.go
+++ b/aws/beanstalk/deployer.go
@@ -11,7 +11,7 @@ import (
 )
 
 func NewDeployer(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, appDetails app.Details) (app.Deployer, error) {
-	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace)
+	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace, appDetails.WorkspaceConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/beanstalk/pusher.go
+++ b/aws/beanstalk/pusher.go
@@ -10,7 +10,7 @@ import (
 )
 
 func NewPusher(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, appDetails app.Details) (app.Pusher, error) {
-	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace)
+	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace, appDetails.WorkspaceConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/cdn/deploy_status_getter.go
+++ b/aws/cdn/deploy_status_getter.go
@@ -10,7 +10,7 @@ import (
 )
 
 func NewDeployStatusGetter(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, appDetails app.Details) (app.DeployStatusGetter, error) {
-	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace)
+	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace, appDetails.WorkspaceConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/cdn/deployer.go
+++ b/aws/cdn/deployer.go
@@ -9,7 +9,7 @@ import (
 )
 
 func NewDeployer(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, appDetails app.Details) (app.Deployer, error) {
-	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace)
+	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace, appDetails.WorkspaceConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/cloudwatch/log_streamer.go
+++ b/aws/cloudwatch/log_streamer.go
@@ -19,7 +19,7 @@ var (
 )
 
 func NewLogStreamer(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, appDetails app.Details) (app.LogStreamer, error) {
-	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace)
+	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace, appDetails.WorkspaceConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/cloudwatch/metrics/getter.go
+++ b/aws/cloudwatch/metrics/getter.go
@@ -15,7 +15,7 @@ import (
 var _ workspace.MetricsGetter = Getter{}
 
 func NewGetter(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, blockDetails workspace.Details) (workspace.MetricsGetter, error) {
-	outs, err := outputs.Retrieve[Outputs](ctx, source, blockDetails.Workspace)
+	outs, err := outputs.Retrieve[Outputs](ctx, source, blockDetails.Workspace, blockDetails.WorkspaceConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/ecr/pusher.go
+++ b/aws/ecr/pusher.go
@@ -24,7 +24,7 @@ type Outputs struct {
 }
 
 func NewPusher(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, appDetails app.Details) (app.Pusher, error) {
-	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace)
+	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace, appDetails.WorkspaceConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/ecs/deploy_logger.go
+++ b/aws/ecs/deploy_logger.go
@@ -39,7 +39,7 @@ type DeployLogger struct {
 }
 
 func NewDeployLogger(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, appDetails app.Details) (app.DeployStatusGetter, error) {
-	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace)
+	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace, appDetails.WorkspaceConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/ecs/deploy_status_getter.go
+++ b/aws/ecs/deploy_status_getter.go
@@ -12,7 +12,7 @@ import (
 )
 
 func NewDeployStatusGetter(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, appDetails app.Details) (app.DeployStatusGetter, error) {
-	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace)
+	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace, appDetails.WorkspaceConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/ecs/deployer.go
+++ b/aws/ecs/deployer.go
@@ -9,7 +9,7 @@ import (
 )
 
 func NewDeployer(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, appDetails app.Details) (app.Deployer, error) {
-	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace)
+	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace, appDetails.WorkspaceConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/ecs/statuser.go
+++ b/aws/ecs/statuser.go
@@ -31,7 +31,7 @@ type Status struct {
 }
 
 func NewStatuser(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, appDetails app.Details) (app.Statuser, error) {
-	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace)
+	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace, appDetails.WorkspaceConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/lambda-container/deployer.go
+++ b/aws/lambda-container/deployer.go
@@ -13,7 +13,7 @@ import (
 )
 
 func NewDeployer(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, appDetails app.Details) (app.Deployer, error) {
-	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace)
+	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace, appDetails.WorkspaceConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/lambda-zip/deployer.go
+++ b/aws/lambda-zip/deployer.go
@@ -13,7 +13,7 @@ import (
 )
 
 func NewDeployer(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, appDetails app.Details) (app.Deployer, error) {
-	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace)
+	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace, appDetails.WorkspaceConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/s3/deployer.go
+++ b/aws/s3/deployer.go
@@ -12,7 +12,7 @@ import (
 )
 
 func NewDeployer(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, appDetails app.Details) (app.Deployer, error) {
-	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace)
+	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace, appDetails.WorkspaceConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/s3/dir_pusher.go
+++ b/aws/s3/dir_pusher.go
@@ -11,7 +11,7 @@ import (
 )
 
 func NewDirPusher(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, appDetails app.Details) (app.Pusher, error) {
-	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace)
+	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace, appDetails.WorkspaceConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/s3/zip_pusher.go
+++ b/aws/s3/zip_pusher.go
@@ -11,7 +11,7 @@ import (
 )
 
 func NewZipPusher(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, appDetails app.Details) (app.Pusher, error) {
-	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace)
+	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace, appDetails.WorkspaceConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/gcp/gcr/pusher.go
+++ b/gcp/gcr/pusher.go
@@ -22,7 +22,7 @@ type Outputs struct {
 }
 
 func NewPusher(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, appDetails app.Details) (app.Pusher, error) {
-	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace)
+	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace, appDetails.WorkspaceConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/gcp/gke/deploy_status_getter.go
+++ b/gcp/gke/deploy_status_getter.go
@@ -16,7 +16,7 @@ import (
 )
 
 func NewDeployStatusGetter(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, appDetails app.Details) (app.DeployStatusGetter, error) {
-	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace)
+	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace, appDetails.WorkspaceConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/gcp/gke/deployer.go
+++ b/gcp/gke/deployer.go
@@ -16,7 +16,7 @@ const (
 )
 
 func NewDeployer(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, appDetails app.Details) (app.Deployer, error) {
-	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace)
+	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace, appDetails.WorkspaceConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/gcp/gke/log_streamer.go
+++ b/gcp/gke/log_streamer.go
@@ -10,7 +10,7 @@ import (
 )
 
 func NewLogStreamer(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, appDetails app.Details) (app.LogStreamer, error) {
-	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace)
+	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace, appDetails.WorkspaceConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/vmihailenco/tagparser v0.1.2
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240305124723-d7bade08dd66
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240518193948-a9070ae47b68
 	k8s.io/api v0.27.2
 	k8s.io/apimachinery v0.27.2
 	k8s.io/client-go v0.27.2

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/vmihailenco/tagparser v0.1.2
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240518193948-a9070ae47b68
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240519011433-55861e524a68
 	k8s.io/api v0.27.2
 	k8s.io/apimachinery v0.27.2
 	k8s.io/client-go v0.27.2

--- a/go.sum
+++ b/go.sum
@@ -1457,8 +1457,8 @@ gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKW
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240305124723-d7bade08dd66 h1:GD2xxBImwzO0FM9TaMjX1TkSaT+KK068o+y3+jtMPoc=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240305124723-d7bade08dd66/go.mod h1:+cdH05EoXHHcFjSvRMXaaOhHSAmEj7tId0b+7R+N7qE=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240518193948-a9070ae47b68 h1:Ol7mckNc7aI8wp/El/zFzt34l85zlBkgGLlIgw0zBqk=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240518193948-a9070ae47b68/go.mod h1:+cdH05EoXHHcFjSvRMXaaOhHSAmEj7tId0b+7R+N7qE=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1 h1:d4KQkxAaAiRY2h5Zqis161Pv91A37uZyJOx73duwUwM=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1/go.mod h1:WbjuEoo1oadwzQ4apSDU+JTvmllEHtsNHS6y7vFc7iw=

--- a/go.sum
+++ b/go.sum
@@ -1457,8 +1457,8 @@ gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKW
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240518193948-a9070ae47b68 h1:Ol7mckNc7aI8wp/El/zFzt34l85zlBkgGLlIgw0zBqk=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240518193948-a9070ae47b68/go.mod h1:+cdH05EoXHHcFjSvRMXaaOhHSAmEj7tId0b+7R+N7qE=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240519011433-55861e524a68 h1:iQ19uwlsk0bkeMlunfmedubmRkL9NK2GxK1nmgzSLV4=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20240519011433-55861e524a68/go.mod h1:+cdH05EoXHHcFjSvRMXaaOhHSAmEj7tId0b+7R+N7qE=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1 h1:d4KQkxAaAiRY2h5Zqis161Pv91A37uZyJOx73duwUwM=
 gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.1/go.mod h1:WbjuEoo1oadwzQ4apSDU+JTvmllEHtsNHS6y7vFc7iw=

--- a/outputs/api_retriever_source.go
+++ b/outputs/api_retriever_source.go
@@ -18,6 +18,11 @@ func (s ApiRetrieverSource) GetWorkspace(ctx context.Context, stackId, blockId, 
 	return nsClient.Workspaces().Get(ctx, stackId, blockId, envId)
 }
 
+func (s ApiRetrieverSource) GetCurrentConfig(ctx context.Context, stackId, blockId, envId int64) (*types.WorkspaceConfig, error) {
+	nsClient := api.Client{Config: s.Config}
+	return nsClient.WorkspaceConfigs().GetCurrent(ctx, stackId, blockId, envId)
+}
+
 func (s ApiRetrieverSource) GetCurrentOutputs(ctx context.Context, stackId int64, workspaceUid uuid.UUID, showSensitive bool) (types.Outputs, error) {
 	nsClient := api.Client{Config: s.Config}
 	return nsClient.WorkspaceOutputs().GetCurrent(ctx, stackId, workspaceUid, showSensitive)

--- a/outputs/mock_ns.go
+++ b/outputs/mock_ns.go
@@ -21,6 +21,15 @@ func mockNs(workspaces []types.Workspace, currentOutputs map[string]types.Output
 			raw, _ := json.Marshal(cur)
 			w.Write(raw)
 		}))
+		configsEndpoint := fmt.Sprintf("/orgs/%s/stacks/%d/blocks/%d/envs/%d/configs/current", cur.OrgName, cur.StackId, cur.BlockId, cur.EnvId)
+		mux.Handle(configsEndpoint, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if cur.LastFinishedRun == nil || cur.LastFinishedRun.Config == nil {
+				w.Write([]byte(`{}`))
+			} else {
+				raw, _ := json.Marshal(cur.LastFinishedRun.Config)
+				w.Write(raw)
+			}
+		}))
 		outputsEndpoint := fmt.Sprintf("/orgs/%s/stacks/%d/workspaces/%s/current-outputs",
 			cur.OrgName, cur.StackId, cur.Uid)
 		mux.Handle(outputsEndpoint, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/outputs/retriever_test.go
+++ b/outputs/retriever_test.go
@@ -151,7 +151,8 @@ func TestRetriever_Retrieve(t *testing.T) {
 
 		retriever := Retriever{Source: ApiRetrieverSource{Config: nsConfig}}
 		var got MockFlatOutputs
-		if assert.NoError(t, retriever.Retrieve(context.Background(), flatWorkspace, &got)) {
+		rw := NewRetrieveWorkspace(flatWorkspace, nil)
+		if assert.NoError(t, retriever.Retrieve(context.Background(), rw, &got)) {
 			assert.Equal(t, want, got)
 		}
 	})
@@ -184,7 +185,8 @@ func TestRetriever_Retrieve(t *testing.T) {
 
 		retriever := Retriever{Source: ApiRetrieverSource{Config: nsConfig}}
 		var got MockDeepOutputs
-		if assert.NoError(t, retriever.Retrieve(context.Background(), deepWorkspace, &got)) {
+		dw := NewRetrieveWorkspace(deepWorkspace, nil)
+		if assert.NoError(t, retriever.Retrieve(context.Background(), dw, &got)) {
 			assert.Equal(t, want, got)
 		}
 	})

--- a/workspace/details.go
+++ b/workspace/details.go
@@ -3,8 +3,9 @@ package workspace
 import "gopkg.in/nullstone-io/go-api-client.v0/types"
 
 type Details struct {
-	Block     *types.Block
-	Env       *types.Environment
-	Workspace *types.Workspace
-	Module    *types.Module
+	Block           *types.Block           `json:"block"`
+	Env             *types.Environment     `json:"env"`
+	Workspace       *types.Workspace       `json:"workspace"`
+	WorkspaceConfig *types.WorkspaceConfig `json:"workspaceConfig"`
+	Module          *types.Module          `json:"module"`
 }


### PR DESCRIPTION
We are now injecting WorkspaceConfig into outputs.Retrieve. This ensures that the correct workspace config is injected into a deployment.

This relies on: https://github.com/nullstone-io/go-api-client/pull/83