### PR TITLE
B/1993/duplicate metric ids

### DIFF
--- a/aws/cloudwatch/metrics/getter.go
+++ b/aws/cloudwatch/metrics/getter.go
@@ -61,7 +61,7 @@ func (g Getter) GetMetrics(ctx context.Context, options workspace.MetricsGetterO
 func (g Getter) ingest(output *cloudwatch.GetMetricDataOutput, result *workspace.MetricsData) {
 	for _, dataResult := range output.MetricDataResults {
 		metricId := *dataResult.Id
-		metricGroup, mapping := g.Infra.MetricsMappings.FindByMetricId(metricId)
+		metricGroup, id, mapping := g.Infra.MetricsMappings.FindByMetricId(metricId)
 		if metricGroup == nil {
 			// This shouldn't happen, it means we don't have a mapping from metric id to its dataset
 			// Should we warn?
@@ -70,7 +70,7 @@ func (g Getter) ingest(output *cloudwatch.GetMetricDataOutput, result *workspace
 		if mapping.HideFromResults {
 			continue
 		}
-		curSeries := result.GetDataset(metricGroup.Name, metricGroup.Type, metricGroup.Unit).GetSeries(metricId)
+		curSeries := result.GetDataset(metricGroup.Name, metricGroup.Type, metricGroup.Unit).GetSeries(id, metricId)
 		for i := 0; i < len(dataResult.Timestamps); i++ {
 			curSeries.AddPoint(dataResult.Timestamps[i], dataResult.Values[i])
 		}

--- a/aws/cloudwatch/metrics/getter.go
+++ b/aws/cloudwatch/metrics/getter.go
@@ -61,13 +61,13 @@ func (g Getter) GetMetrics(ctx context.Context, options workspace.MetricsGetterO
 func (g Getter) ingest(output *cloudwatch.GetMetricDataOutput, result *workspace.MetricsData) {
 	for _, dataResult := range output.MetricDataResults {
 		metricId := *dataResult.Id
-		metricGroup := g.Infra.MetricsMappings.FindGroupByMetricId(metricId)
+		metricGroup, mapping := g.Infra.MetricsMappings.FindByMetricId(metricId)
 		if metricGroup == nil {
 			// This shouldn't happen, it means we don't have a mapping from metric id to its dataset
 			// Should we warn?
 			continue
 		}
-		if metricGroup.Mappings[metricId].HideFromResults {
+		if mapping.HideFromResults {
 			continue
 		}
 		curSeries := result.GetDataset(metricGroup.Name, metricGroup.Type, metricGroup.Unit).GetSeries(metricId)

--- a/aws/cloudwatch/metrics/mappings.go
+++ b/aws/cloudwatch/metrics/mappings.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"fmt"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/nullstone-io/deployment-sdk/workspace"
@@ -62,12 +63,13 @@ func (d MetricMappingDimensions) ToAws() []types.Dimension {
 
 func (g MappingGroups) BuildMetricQueries(metrics []string, periodSec int32) []types.MetricDataQuery {
 	queries := make([]types.MetricDataQuery, 0)
-	for _, grp := range g {
+	for i, grp := range g {
 		if len(metrics) < 1 || slices.Contains(metrics, grp.Name) {
 			// This Metric Group was specified in the list of requested metrics
 			// Let's build a query and add it
 			for id, mapping := range grp.Mappings {
-				queries = append(queries, mapping.ToMetricDateQuery(id, periodSec))
+				uniqueId := fmt.Sprintf("group_%d_%s", i, id)
+				queries = append(queries, mapping.ToMetricDateQuery(uniqueId, periodSec))
 			}
 		}
 	}
@@ -75,8 +77,9 @@ func (g MappingGroups) BuildMetricQueries(metrics []string, periodSec int32) []t
 }
 
 func (g MappingGroups) FindGroupByMetricId(id string) *MappingGroup {
-	for _, grp := range g {
-		if _, ok := grp.Mappings[id]; ok {
+	for i, grp := range g {
+		uniqueId := fmt.Sprintf("group_%d_%s", i, id)
+		if _, ok := grp.Mappings[uniqueId]; ok {
 			return &grp
 		}
 	}

--- a/aws/cloudwatch/metrics/mappings.go
+++ b/aws/cloudwatch/metrics/mappings.go
@@ -4,7 +4,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/nullstone-io/deployment-sdk/workspace"
-	"k8s.io/utils/strings/slices"
+	"slices"
 )
 
 type MappingGroups []MappingGroup

--- a/aws/cloudwatch/metrics/mappings.go
+++ b/aws/cloudwatch/metrics/mappings.go
@@ -75,15 +75,15 @@ func (g MappingGroups) BuildMetricQueries(metrics []string, periodSec int32) []t
 	return queries
 }
 
-func (g MappingGroups) FindGroupByMetricId(metricId string) *MappingGroup {
+func (g MappingGroups) FindByMetricId(metricId string) (*MappingGroup, MetricMapping) {
 	for i, grp := range g {
-		for id, _ := range grp.Mappings {
+		for id, mapping := range grp.Mappings {
 			if g.genMetricId(i, id) == metricId {
-				return &grp
+				return &grp, mapping
 			}
 		}
 	}
-	return nil
+	return nil, MetricMapping{}
 }
 
 func (g MappingGroups) genMetricId(i int, id string) string {

--- a/aws/cloudwatch/metrics/mappings.go
+++ b/aws/cloudwatch/metrics/mappings.go
@@ -75,15 +75,15 @@ func (g MappingGroups) BuildMetricQueries(metrics []string, periodSec int32) []t
 	return queries
 }
 
-func (g MappingGroups) FindByMetricId(metricId string) (*MappingGroup, MetricMapping) {
+func (g MappingGroups) FindByMetricId(metricId string) (*MappingGroup, string, MetricMapping) {
 	for i, grp := range g {
 		for id, mapping := range grp.Mappings {
 			if g.genMetricId(i, id) == metricId {
-				return &grp, mapping
+				return &grp, id, mapping
 			}
 		}
 	}
-	return nil, MetricMapping{}
+	return nil, "", MetricMapping{}
 }
 
 func (g MappingGroups) genMetricId(i int, id string) string {

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,6 @@ require (
 	k8s.io/apimachinery v0.27.2
 	k8s.io/client-go v0.27.2
 	k8s.io/kubectl v0.27.1
-	k8s.io/utils v0.0.0-20230209194617-a36077c30491
 )
 
 require (
@@ -148,6 +147,7 @@ require (
 	k8s.io/component-base v0.27.1 // indirect
 	k8s.io/klog/v2 v2.90.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // indirect
+	k8s.io/utils v0.0.0-20230209194617-a36077c30491 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kustomize/api v0.13.2 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.14.1 // indirect

--- a/workspace/metrics_data.go
+++ b/workspace/metrics_data.go
@@ -41,9 +41,16 @@ func NewMetricDataset(metricName string, metricType MetricDatasetType, unit stri
 	}
 }
 
+// MetricDataset contains all data and labels for a single chart
+// The Series contained are plotted on the same chart
 type MetricDataset struct {
-	Name   string                   `json:"name"`
-	Type   MetricDatasetType        `json:"type"`
+	// Name is displayed in the title of the chart
+	Name string `json:"name"`
+	// Type is the kind of metric that is used to select what type of chart to use
+	Type MetricDatasetType `json:"type"`
+	// Unit is the unit of measurement for the entire chart
+	// All Series in this MetricDataset must use the same unit of measurement
+	// The unit of measurement is added to the title as `<name> (<unit>)`
 	Unit   string                   `json:"unit"`
 	Series map[string]*MetricSeries `json:"series"`
 }
@@ -56,19 +63,20 @@ const (
 	MetricDatasetTypeDuration    = "duration"
 )
 
-func (d *MetricDataset) GetSeries(metricId string) *MetricSeries {
-	if existing, ok := d.Series[metricId]; ok {
+func (d *MetricDataset) GetSeries(id, metricId string) *MetricSeries {
+	if existing, ok := d.Series[id]; ok {
 		return existing
 	}
 
-	ms := NewMetricSeries(metricId)
-	d.Series[metricId] = ms
+	ms := NewMetricSeries(id, metricId)
+	d.Series[id] = ms
 	return ms
 }
 
-func NewMetricSeries(id string) *MetricSeries {
+func NewMetricSeries(id, metricId string) *MetricSeries {
 	return &MetricSeries{
 		Id:         id,
+		MetricId:   metricId,
 		MinValue:   math.MaxFloat64,
 		MaxValue:   0,
 		Datapoints: make([]MetricDataPoint, 0),
@@ -76,8 +84,13 @@ func NewMetricSeries(id string) *MetricSeries {
 }
 
 type MetricSeries struct {
-	Id         string            `json:"id"`
-	MinValue   float64           `json:"minValue"`
+	// Id is used as the label and unique identifier within a single chart
+	Id string `json:"id"`
+	// MetricId is a unique identifier across all MetricDatasets in order to safely query from the metrics provider
+	MetricId string `json:"metricId"`
+	// MinValue is used to identify the lowest y-value on the chart
+	MinValue float64 `json:"minValue"`
+	// MaxValue is used to identify the highest y-value on the chart
 	MaxValue   float64           `json:"maxValue"`
 	Datapoints []MetricDataPoint `json:"datapoints"`
 }


### PR DESCRIPTION
A customer added 2 HTTP Load Balancer capabilities.
This module exports metrics mappings: a set of response data for each load balancer.
As a result, the metrics getter in the deployment-sdk created a faulty query to AWS for this metric data.
The query includes an ID that was not unique because there were 2 HTTP Load Balancers.
This fix generates unique IDs for the metrics query.