### PR TITLE
F2091 gar pusher

### DIFF
--- a/app/container/gcp-gke-service/provider.go
+++ b/app/container/gcp-gke-service/provider.go
@@ -2,7 +2,7 @@ package gcp_gke_service
 
 import (
 	"github.com/nullstone-io/deployment-sdk/app"
-	"github.com/nullstone-io/deployment-sdk/gcp/gcr"
+	"github.com/nullstone-io/deployment-sdk/gcp"
 	"github.com/nullstone-io/deployment-sdk/gcp/gke"
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
 )
@@ -17,7 +17,7 @@ var ModuleContractName = types.ModuleContractName{
 
 var Provider = app.Provider{
 	CanDeployImmediate: false,
-	NewPusher:          gcr.NewPusher,
+	NewPusher:          gcp.NewPusher,
 	NewDeployer:        gke.NewDeployer,
 	NewDeployWatcher:   app.NewPollingDeployWatcher(gke.NewDeployStatusGetter),
 	NewStatuser:        nil,

--- a/gcp/pusher.go
+++ b/gcp/pusher.go
@@ -1,0 +1,61 @@
+package gcp
+
+import (
+	"context"
+	"github.com/nullstone-io/deployment-sdk/app"
+	"github.com/nullstone-io/deployment-sdk/docker"
+	"github.com/nullstone-io/deployment-sdk/gcp/gar"
+	"github.com/nullstone-io/deployment-sdk/gcp/gcr"
+	"github.com/nullstone-io/deployment-sdk/logging"
+	"github.com/nullstone-io/deployment-sdk/outputs"
+	"strings"
+)
+
+type Outputs struct {
+	ImageRepoUrl docker.ImageUrl `ns:"image_repo_url,optional"`
+	ImagePusher  ServiceAccount  `ns:"image_pusher,optional"`
+}
+
+func NewPusher(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, appDetails app.Details) (app.Pusher, error) {
+	outs, err := outputs.Retrieve[Outputs](ctx, source, appDetails.Workspace, appDetails.WorkspaceConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &Pusher{
+		OsWriters: osWriters,
+		Infra:     outs,
+	}, nil
+}
+
+var _ app.Pusher = &Pusher{}
+
+type Pusher struct {
+	OsWriters logging.OsWriters
+	Infra     Outputs
+}
+
+func (p Pusher) Push(ctx context.Context, source, version string) error {
+	pusher := p.getInfraSpecificPusher()
+	return pusher.Push(ctx, source, version)
+}
+
+func (p Pusher) ListArtifactVersions(ctx context.Context) ([]string, error) {
+	pusher := p.getInfraSpecificPusher()
+	return pusher.ListArtifactVersions(ctx)
+}
+
+func (p Pusher) getInfraSpecificPusher() app.Pusher {
+	targetUrl := p.Infra.ImageRepoUrl
+	// the new google artifact registry has a url with docker.pkg.dev in it
+	// otherwise we fall back to the old gcr.io registry
+	if strings.Contains(targetUrl.Registry, "docker.pkg.dev") {
+		return gar.Pusher{
+			OsWriters: p.OsWriters,
+			Infra:     p.Infra,
+		}
+	}
+	return gcr.Pusher{
+		OsWriters: p.OsWriters,
+		Infra:     p.Infra,
+	}
+}


### PR DESCRIPTION
This PR adds a new gar pusher for the google artifact registry. It also adds logic to split and choose the right underlying pusher based on the registry url.