### PR TITLE
F/2117/gke job run

### DIFF
--- a/app/log_streamer.go
+++ b/app/log_streamer.go
@@ -21,6 +21,10 @@ type LogStreamOptions struct {
 	// For AWS Cloudwatch: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html
 	Pattern *string
 
+	// A filter to apply when querying the log source
+	// For Kubernetes, this is a label selector to further filter down the logs
+	Selector *string
+
 	// WatchInterval dictates how often the log streamer will query AWS for new events
 	// If left unspecified or 0, will use default watch interval of 1s
 	// If a negative value is specified, watching will disable, the log streamer will terminate as soon as logs are emitted

--- a/gcp/gke/log_streamer.go
+++ b/gcp/gke/log_streamer.go
@@ -20,7 +20,7 @@ func NewLogStreamer(ctx context.Context, osWriters logging.OsWriters, source out
 		OsWriters:    osWriters,
 		Details:      appDetails,
 		AppNamespace: outs.ServiceNamespace,
-		AppName:      outs.ServiceName,
+		AppName:      appDetails.App.Name,
 		NewConfigFn: func(ctx context.Context) (*rest.Config, error) {
 			return CreateKubeConfig(ctx, outs.ClusterNamespace, outs.Deployer)
 		},

--- a/gcp/gke/outputs.go
+++ b/gcp/gke/outputs.go
@@ -20,6 +20,7 @@ type Outputs struct {
 	ImageRepoUrl      docker.ImageUrl    `ns:"image_repo_url,optional"`
 	Deployer          gcp.ServiceAccount `ns:"deployer"`
 	MainContainerName string             `ns:"main_container_name,optional"`
+	JobDefinitionName string             `ns:"job_definition_name,optional"`
 
 	ClusterNamespace ClusterNamespaceOutputs `ns:",connectionContract:cluster-namespace/gcp/k8s:gke"`
 }

--- a/k8s/get_container_by_name.go
+++ b/k8s/get_container_by_name.go
@@ -1,15 +1,14 @@
 package k8s
 
 import (
-	v1 "k8s.io/api/apps/v1"
-	core_v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
-func GetContainerByName(deployment v1.Deployment, name string) (int, *core_v1.Container) {
-	for i, container := range deployment.Spec.Template.Spec.Containers {
+func GetContainerByName(podTemplateSpec corev1.PodTemplateSpec, name string) (int, *corev1.Container) {
+	for i, container := range podTemplateSpec.Spec.Containers {
 		if container.Name == name {
 			return i, &container
 		}
 	}
-	return -1, &core_v1.Container{}
+	return -1, &corev1.Container{}
 }

--- a/k8s/get_job_definition.go
+++ b/k8s/get_job_definition.go
@@ -1,0 +1,41 @@
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func GetJobDefinition(ctx context.Context, client *kubernetes.Clientset, namespace string, name string) (*batchv1.Job, *v1.ConfigMap, error) {
+	configMap, err := client.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to retrieve job template: %w", err)
+	} else if configMap == nil {
+		return nil, nil, fmt.Errorf("job template (%s) does not exist in Kubernetes namespace (%s)", name, namespace)
+	}
+
+	// The job template is stored in the "template" field as a json blob
+	var jobDef batchv1.Job
+	val, ok := configMap.Data["template"]
+	if !ok {
+		return nil, nil, fmt.Errorf("job template (%s) contains no data for 'template' field", name)
+	}
+	if err := json.Unmarshal([]byte(val), &jobDef); err != nil {
+		return nil, nil, fmt.Errorf("unable to parse job template: %w", err)
+	}
+	return &jobDef, configMap, nil
+}
+
+func UpdateJobDefinition(ctx context.Context, client *kubernetes.Clientset, namespace string, jobDef *batchv1.Job, configMap *v1.ConfigMap) error {
+	raw, err := json.Marshal(jobDef)
+	if err != nil {
+		return fmt.Errorf("unable to serialize job definition to config map: %w", err)
+	}
+	configMap.Data["template"] = string(raw)
+	_, err = client.CoreV1().ConfigMaps(namespace).Update(ctx, configMap, metav1.UpdateOptions{})
+	return err
+}

--- a/k8s/log_streamer.go
+++ b/k8s/log_streamer.go
@@ -40,7 +40,10 @@ func (l LogStreamer) Stream(ctx context.Context, options app.LogStreamOptions) e
 		options.Emitter = app.NewWriterLogEmitter(os.Stdout)
 	}
 
-	appLabel := fmt.Sprintf("nullstone.io/app=%s", l.AppName)
+	selector := fmt.Sprintf("nullstone.io/app=%s", l.AppName)
+	if options.Selector != nil && len(*options.Selector) > 0 {
+		selector = fmt.Sprintf("%s,%s", selector, *options.Selector)
+	}
 
 	cfg, err := l.NewConfigFn(ctx)
 	if err != nil {
@@ -50,7 +53,7 @@ func (l LogStreamer) Stream(ctx context.Context, options app.LogStreamOptions) e
 	if err != nil {
 		return l.newInitError("There was an error initializing kubernetes client", err)
 	}
-	pods, err := client.CoreV1().Pods(l.AppNamespace).List(ctx, metav1.ListOptions{LabelSelector: appLabel})
+	pods, err := client.CoreV1().Pods(l.AppNamespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
 		return l.newInitError("There was an error looking for application pods", err)
 	}

--- a/k8s/log_streamer.go
+++ b/k8s/log_streamer.go
@@ -42,7 +42,7 @@ func (l LogStreamer) Stream(ctx context.Context, options app.LogStreamOptions) e
 
 	selector := fmt.Sprintf("nullstone.io/app=%s", l.AppName)
 	if options.Selector != nil && len(*options.Selector) > 0 {
-		selector = fmt.Sprintf("%s,%s", selector, *options.Selector)
+		selector = *options.Selector
 	}
 
 	cfg, err := l.NewConfigFn(ctx)

--- a/k8s/update_version_label.go
+++ b/k8s/update_version_label.go
@@ -1,15 +1,14 @@
 package k8s
 
 import (
-	"k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
 	StandardVersionLabel = "app.kubernetes.io/version"
 )
 
-func UpdateVersionLabel(deployment *v1.Deployment, version string) {
-	if _, ok := deployment.ObjectMeta.Labels[StandardVersionLabel]; ok {
-		deployment.ObjectMeta.Labels[StandardVersionLabel] = version
-	}
+func UpdateVersionLabel(meta metav1.ObjectMeta, version string) metav1.ObjectMeta {
+	meta.Labels[StandardVersionLabel] = version
+	return meta
 }


### PR DESCRIPTION
This updates the GKE deployer to handle GKE jobs.
- The job definition is stored in a configmap created in Terraform
- When deploying a job, this configmap is updated
- The GKE log streamer to enable streaming of a specific job