### PR TITLE
F/2154/watch initial deployment

### DIFF
--- a/app/polling_deploy_watcher.go
+++ b/app/polling_deploy_watcher.go
@@ -52,7 +52,7 @@ func NewPollingDeployWatcher(statusGetterFn NewDeployStatusGetterFunc) NewDeploy
 // - ErrFailed: Deployment failed as reported by DeployStatusGetter.GetDeployStatus
 // - CancelError: System cancelled by evicted deployment or via ctx
 // - ErrTimeout: ctx reached timeout or watcher reached 15m timeout
-func (s *PollingDeployWatcher) Watch(ctx context.Context, reference string) error {
+func (s *PollingDeployWatcher) Watch(ctx context.Context, reference string, isFirstDeploy bool) error {
 	stdout := s.OsWriters.Stdout()
 	defer s.StatusGetter.Close()
 

--- a/app/polling_deploy_watcher_test.go
+++ b/app/polling_deploy_watcher_test.go
@@ -110,7 +110,7 @@ func TestPollingDeployWatcher(t *testing.T) {
 			}
 			mockGetter.On("Close")
 
-			err := mockWatcher.Watch(ctx, "stub")
+			err := mockWatcher.Watch(ctx, "stub", false)
 			mockGetter.AssertExpectations(t)
 
 			if test.expects == nil {

--- a/app/provider.go
+++ b/app/provider.go
@@ -37,7 +37,7 @@ type DeployStatusGetter interface {
 }
 
 type DeployWatcher interface {
-	Watch(ctx context.Context, reference string) error
+	Watch(ctx context.Context, reference string, isFirstDeploy bool) error
 }
 
 type Statuser interface {

--- a/aws/ecs/test-fixtures/deploy-watcher/main.go
+++ b/aws/ecs/test-fixtures/deploy-watcher/main.go
@@ -59,7 +59,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	err = watcher.Watch(ctx, *deployment.Id)
+	err = watcher.Watch(ctx, *deployment.Id, false)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/gcp/gke/deployer.go
+++ b/gcp/gke/deployer.go
@@ -82,7 +82,7 @@ func (d Deployer) deployService(ctx context.Context, meta app.DeployMetadata) (s
 	if err != nil {
 		return "", err
 	}
-	curRevisionNum := deployment.Generation
+	curRevision := deployment.Annotations[k8s.RevisionAnnotation]
 
 	// Update deployment definition
 	deployment.ObjectMeta = k8s.UpdateVersionLabel(deployment.ObjectMeta, meta.Version)
@@ -96,13 +96,13 @@ func (d Deployer) deployService(ctx context.Context, meta app.DeployMetadata) (s
 		return "", fmt.Errorf("error deploying app: %w", err)
 	}
 
-	revision := ""
-	updatedRevNum := updated.Generation
-	if updatedRevNum == curRevisionNum {
+	var revision string
+	updatedRevision := updated.Annotations[k8s.RevisionAnnotation]
+	if curRevision == updatedRevision {
 		revision = DeployReferenceNoop
 		fmt.Fprintln(stdout, "No changes made to deployment.")
 	} else {
-		revision = fmt.Sprintf("%d", updatedRevNum)
+		revision = updatedRevision
 		fmt.Fprintf(stdout, "Created new deployment revision %s.\n", revision)
 	}
 

--- a/k8s/deploy_watcher.go
+++ b/k8s/deploy_watcher.go
@@ -43,15 +43,20 @@ type DeployWatcher struct {
 	tracker *AppObjectsTracker
 }
 
-func (w *DeployWatcher) Watch(ctx context.Context, reference string) error {
+func (w *DeployWatcher) Watch(ctx context.Context, reference string, isFirstDeploy bool) error {
 	stdout := w.OsWriters.Stdout()
 	if reference == "" {
 		fmt.Fprintln(stdout, "This deployment does not have to wait for any resource to become healthy.")
 		return nil
 	}
 	if reference == DeployReferenceNoop {
-		fmt.Fprintln(stdout, "This deployment did not cause any changes to the app. Skipping check for healthy.")
-		return nil
+		if isFirstDeploy {
+			fmt.Fprintln(stdout, "Watching initial deployment.")
+			reference = "1"
+		} else {
+			fmt.Fprintln(stdout, "This deployment did not cause any changes to the app. Skipping check for healthy.")
+			return nil
+		}
 	}
 	if err := w.init(ctx); err != nil {
 		return err

--- a/test-harness/deploy-watcher/main.go
+++ b/test-harness/deploy-watcher/main.go
@@ -58,7 +58,7 @@ func main() {
 	}
 
 	dw, err := gke.NewDeployWatcher(ctx, osWriters, rs, appDetails)
-	if err := dw.Watch(ctx, reference); err != nil {
+	if err := dw.Watch(ctx, reference, false); err != nil {
 		log.Fatalln(err)
 	}
 }


### PR DESCRIPTION
This updates the k8s deployer/watcher to always watch the initial k8s deployment.

The deployer was changed to grab the deployment revision annotation rather than the generation to ensure proper lookup in the watcher.