### PR TITLE
Feat/30/enhance k8s statuser

### DIFF
--- a/aws/eks/statuser.go
+++ b/aws/eks/statuser.go
@@ -18,8 +18,12 @@ func NewStatuser(ctx context.Context, osWriters logging.OsWriters, source output
 	outs.InitializeCreds(source, appDetails.Workspace)
 
 	return k8s.Statuser{
-		OsWriters:    osWriters,
-		Details:      appDetails,
+		OsWriters: osWriters,
+		Details:   appDetails,
+		Cluster: k8s.ClusterInfo{
+			Region:      outs.ClusterNamespace.Region,
+			ClusterName: outs.ClusterNamespace.ClusterId,
+		},
 		AppNamespace: outs.ServiceNamespace,
 		AppName:      outs.ServiceName,
 		NewConfigFn: func(ctx context.Context) (*rest.Config, error) {

--- a/aws/eks/statuser.go
+++ b/aws/eks/statuser.go
@@ -17,7 +17,7 @@ func NewStatuser(ctx context.Context, osWriters logging.OsWriters, source output
 	}
 	outs.InitializeCreds(source, appDetails.Workspace)
 
-	return k8s.Statuser{
+	return &k8s.Statuser{
 		OsWriters: osWriters,
 		Details:   appDetails,
 		Cluster: k8s.ClusterInfo{

--- a/aws/eks/statuser.go
+++ b/aws/eks/statuser.go
@@ -25,7 +25,7 @@ func NewStatuser(ctx context.Context, osWriters logging.OsWriters, source output
 			ClusterName: outs.ClusterNamespace.ClusterId,
 		},
 		AppNamespace: outs.ServiceNamespace,
-		AppName:      outs.ServiceName,
+		AppName:      appDetails.App.Name,
 		NewConfigFn: func(ctx context.Context) (*rest.Config, error) {
 			return CreateKubeConfig(ctx, outs.ClusterNamespace, outs.Deployer)
 		},

--- a/gcp/gke/outputs.go
+++ b/gcp/gke/outputs.go
@@ -31,6 +31,9 @@ func (o *Outputs) InitializeCreds(source outputs.RetrieverSource, ws *types.Work
 }
 
 type ClusterNamespaceOutputs struct {
+	ProjectId            string `ns:"project_id,optional"`
+	Region               string `ns:"region,optional"`
+	ClusterName          string `ns:"cluster_name,optional"`
 	ClusterEndpoint      string `ns:"cluster_endpoint"`
 	ClusterCACertificate string `ns:"cluster_ca_certificate"`
 }

--- a/gcp/gke/statuser.go
+++ b/gcp/gke/statuser.go
@@ -17,7 +17,7 @@ func NewStatuser(ctx context.Context, osWriters logging.OsWriters, source output
 	}
 	outs.InitializeCreds(source, appDetails.Workspace)
 
-	return k8s.Statuser{
+	return &k8s.Statuser{
 		OsWriters: osWriters,
 		Details:   appDetails,
 		Cluster: k8s.ClusterInfo{

--- a/gcp/gke/statuser.go
+++ b/gcp/gke/statuser.go
@@ -18,8 +18,13 @@ func NewStatuser(ctx context.Context, osWriters logging.OsWriters, source output
 	outs.InitializeCreds(source, appDetails.Workspace)
 
 	return k8s.Statuser{
-		OsWriters:    osWriters,
-		Details:      appDetails,
+		OsWriters: osWriters,
+		Details:   appDetails,
+		Cluster: k8s.ClusterInfo{
+			Region:      outs.ClusterNamespace.Region,
+			ProjectId:   outs.ClusterNamespace.ProjectId,
+			ClusterName: outs.ClusterNamespace.ClusterName,
+		},
 		AppNamespace: outs.ServiceNamespace,
 		AppName:      outs.ServiceName,
 		NewConfigFn: func(ctx context.Context) (*rest.Config, error) {

--- a/k8s/status.go
+++ b/k8s/status.go
@@ -100,6 +100,10 @@ type AppStatusPod struct {
 	Phase      string                  `json:"phase"`
 	Conditions []AppStatusPodCondition `json:"conditions"`
 	Containers []AppStatusPodContainer `json:"containers"`
+	// MaxRestartCount is the highest RestartCount across the pod's containers.
+	MaxRestartCount int `json:"maxRestartCount"`
+	// LastRestartedAt is the LastRestartedAt of the container with MaxRestartCount, or nil if no container has restarted.
+	LastRestartedAt *time.Time `json:"lastRestartedAt"`
 }
 
 type AppStatusPodCondition struct {
@@ -114,9 +118,15 @@ type AppStatusPodCondition struct {
 
 func AppStatusPodFromK8s(pod corev1.Pod, svcs []corev1.Service) AppStatusPod {
 	containers := make([]AppStatusPodContainer, 0)
+	maxRestartCount := 0
+	var lastRestartedAt *time.Time
 	for _, cur := range pod.Spec.Containers {
 		container := AppStatusContainerFromK8s(cur, findPodContainerStatus(pod, cur), svcs)
 		containers = append(containers, container)
+		if container.RestartCount > maxRestartCount {
+			maxRestartCount = container.RestartCount
+			lastRestartedAt = container.LastRestartedAt
+		}
 	}
 
 	var startTime *time.Time
@@ -141,13 +151,15 @@ func AppStatusPodFromK8s(pod corev1.Pod, svcs []corev1.Service) AppStatusPod {
 	}
 
 	return AppStatusPod{
-		Name:       pod.Name,
-		CreatedAt:  pod.CreationTimestamp.Time,
-		StartedAt:  startTime,
-		ReplicaSet: findPodReplicaSet(pod),
-		Phase:      string(pod.Status.Phase),
-		Containers: containers,
-		Conditions: conditions,
+		Name:            pod.Name,
+		CreatedAt:       pod.CreationTimestamp.Time,
+		StartedAt:       startTime,
+		ReplicaSet:      findPodReplicaSet(pod),
+		Phase:           string(pod.Status.Phase),
+		Containers:      containers,
+		Conditions:      conditions,
+		MaxRestartCount: maxRestartCount,
+		LastRestartedAt: lastRestartedAt,
 	}
 }
 
@@ -158,7 +170,10 @@ type AppStatusPodContainer struct {
 	Ready        bool                        `json:"ready"`
 	Started      bool                        `json:"started"`
 	RestartCount int                         `json:"restartCount"`
-	Ports        []AppStatusPodContainerPort `json:"ports"`
+	// LastRestartedAt is when the most recent restart occurred (the previous instance's termination time),
+	// or nil if the container has never restarted.
+	LastRestartedAt *time.Time                  `json:"lastRestartedAt"`
+	Ports           []AppStatusPodContainerPort `json:"ports"`
 }
 
 func AppStatusContainerFromK8s(container corev1.Container, status *corev1.ContainerStatus, svcs []corev1.Service) AppStatusPodContainer {
@@ -183,20 +198,31 @@ func AppStatusContainerFromK8s(container corev1.Container, status *corev1.Contai
 	var ready bool
 	var started bool
 	var restartCount int
+	var lastRestartedAt *time.Time
 	if status != nil {
 		ready = status.Ready
 		started = status.Started != nil && *status.Started
 		restartCount = int(status.RestartCount)
+		if restartCount > 0 {
+			if term := status.LastTerminationState.Terminated; term != nil && !term.FinishedAt.IsZero() {
+				t := term.FinishedAt.Time
+				lastRestartedAt = &t
+			} else if running := status.State.Running; running != nil && !running.StartedAt.IsZero() {
+				t := running.StartedAt.Time
+				lastRestartedAt = &t
+			}
+		}
 	}
 
 	return AppStatusPodContainer{
-		Name:         container.Name,
-		Image:        container.Image,
-		Command:      container.Command,
-		Ready:        ready,
-		Started:      started,
-		RestartCount: restartCount,
-		Ports:        ports,
+		Name:            container.Name,
+		Image:           container.Image,
+		Command:         container.Command,
+		Ready:           ready,
+		Started:         started,
+		RestartCount:    restartCount,
+		LastRestartedAt: lastRestartedAt,
+		Ports:           ports,
 	}
 }
 

--- a/k8s/status.go
+++ b/k8s/status.go
@@ -7,8 +7,20 @@ import (
 	"time"
 )
 
+// ClusterInfo identifies the cloud cluster an app is running on. Distinct from
+// the ClusterInfoer interface (which produces kube-config Cluster details for
+// auth) — this carries the human/cloud-provider identifiers used in status output.
+type ClusterInfo struct {
+	Region      string `json:"region"`
+	ProjectId   string `json:"projectId"`
+	ClusterName string `json:"clusterName"`
+}
+
 type AppStatus struct {
-	ReplicaSets []AppStatusReplicaSet `json:"replicaSets"`
+	Cluster        ClusterInfo           `json:"cluster"`
+	Namespace      string                `json:"namespace"`
+	DeploymentName string                `json:"deploymentName"`
+	ReplicaSets    []AppStatusReplicaSet `json:"replicaSets"`
 }
 
 type AppStatusReplicaSet struct {

--- a/k8s/status.go
+++ b/k8s/status.go
@@ -12,20 +12,21 @@ type AppStatus struct {
 }
 
 type AppStatusReplicaSet struct {
-	Name              string    `json:"name"`
-	Revision          int       `json:"revision"`
-	Generation        int64     `json:"generation"`
-	AppVersion        string    `json:"appVersion"`
-	CreatedAt         time.Time `json:"createdAt"`
-	DesiredReplicas   int       `json:"desiredReplicas"`
-	AvailableReplicas int       `json:"availableReplicas"`
-	ReadyReplicas     int       `json:"readyReplicas"`
-	Replicas          int       `json:"replicas"`
+	Name              string                    `json:"name"`
+	Revision          int                       `json:"revision"`
+	Generation        int64                     `json:"generation"`
+	AppVersion        string                    `json:"appVersion"`
+	CreatedAt         time.Time                 `json:"createdAt"`
+	DesiredReplicas   int                       `json:"desiredReplicas"`
+	AvailableReplicas int                       `json:"availableReplicas"`
+	ReadyReplicas     int                       `json:"readyReplicas"`
+	Replicas          int                       `json:"replicas"`
+	Ports             []AppStatusReplicaSetPort `json:"ports"`
 
 	Pods []AppStatusPod `json:"pods"`
 }
 
-func AppStatusReplicaSetFromK8s(rs appsv1.ReplicaSet) AppStatusReplicaSet {
+func AppStatusReplicaSetFromK8s(rs appsv1.ReplicaSet, svcs []corev1.Service) AppStatusReplicaSet {
 	desired := 0
 	if val, err := strconv.Atoi(rs.Annotations["deployment.kubernetes.io/desired-replicas"]); err == nil {
 		desired = val
@@ -41,8 +42,40 @@ func AppStatusReplicaSetFromK8s(rs appsv1.ReplicaSet) AppStatusReplicaSet {
 		AvailableReplicas: int(rs.Status.AvailableReplicas),
 		ReadyReplicas:     int(rs.Status.ReadyReplicas),
 		Replicas:          int(rs.Status.Replicas),
+		Ports:             AggregateReplicaSetPorts(rs, svcs),
 		Pods:              make([]AppStatusPod, 0),
 	}
+}
+
+type AppStatusReplicaSetPort struct {
+	Protocol      string `json:"protocol"`
+	HostPort      int    `json:"hostPort"`
+	ContainerName string `json:"containerName"`
+	ContainerPort int    `json:"containerPort"`
+}
+
+// AggregateReplicaSetPorts derives the host->container port mappings for a replica set
+// by matching the pod template's container ports against the target ports of the given services.
+func AggregateReplicaSetPorts(rs appsv1.ReplicaSet, svcs []corev1.Service) []AppStatusReplicaSetPort {
+	ports := make([]AppStatusReplicaSetPort, 0)
+	for _, container := range rs.Spec.Template.Spec.Containers {
+		for _, svc := range svcs {
+			for _, port := range svc.Spec.Ports {
+				svcPort := port.TargetPort.IntValue()
+				for _, cport := range container.Ports {
+					if int(cport.ContainerPort) == svcPort {
+						ports = append(ports, AppStatusReplicaSetPort{
+							Protocol:      string(cport.Protocol),
+							HostPort:      int(port.Port),
+							ContainerName: container.Name,
+							ContainerPort: int(cport.ContainerPort),
+						})
+					}
+				}
+			}
+		}
+	}
+	return ports
 }
 
 type AppStatusPods []AppStatusPod
@@ -119,10 +152,13 @@ func AppStatusPodFromK8s(pod corev1.Pod, svcs []corev1.Service) AppStatusPod {
 }
 
 type AppStatusPodContainer struct {
-	Name    string                      `json:"name"`
-	Ready   bool                        `json:"ready"`
-	Started bool                        `json:"started"`
-	Ports   []AppStatusPodContainerPort `json:"ports"`
+	Name         string                      `json:"name"`
+	Image        string                      `json:"image"`
+	Command      []string                    `json:"command"`
+	Ready        bool                        `json:"ready"`
+	Started      bool                        `json:"started"`
+	RestartCount int                         `json:"restartCount"`
+	Ports        []AppStatusPodContainerPort `json:"ports"`
 }
 
 func AppStatusContainerFromK8s(container corev1.Container, status *corev1.ContainerStatus, svcs []corev1.Service) AppStatusPodContainer {
@@ -146,16 +182,21 @@ func AppStatusContainerFromK8s(container corev1.Container, status *corev1.Contai
 
 	var ready bool
 	var started bool
+	var restartCount int
 	if status != nil {
 		ready = status.Ready
 		started = status.Started != nil && *status.Started
+		restartCount = int(status.RestartCount)
 	}
 
 	return AppStatusPodContainer{
-		Name:    container.Name,
-		Ready:   ready,
-		Started: started,
-		Ports:   ports,
+		Name:         container.Name,
+		Image:        container.Image,
+		Command:      container.Command,
+		Ready:        ready,
+		Started:      started,
+		RestartCount: restartCount,
+		Ports:        ports,
 	}
 }
 

--- a/k8s/status.go
+++ b/k8s/status.go
@@ -18,10 +18,11 @@ type ClusterInfo struct {
 }
 
 type AppStatus struct {
-	Cluster        ClusterInfo           `json:"cluster"`
-	Namespace      string                `json:"namespace"`
-	DeploymentName string                `json:"deploymentName"`
-	ReplicaSets    []AppStatusReplicaSet `json:"replicaSets"`
+	Cluster        ClusterInfo             `json:"cluster"`
+	Namespace      string                  `json:"namespace"`
+	DeploymentName string                  `json:"deploymentName"`
+	ReplicaSets    []AppStatusReplicaSet   `json:"replicaSets"`
+	Jobs           []AppStatusJobExecution `json:"jobs"`
 }
 
 type AppStatusReplicaSet struct {

--- a/k8s/status.go
+++ b/k8s/status.go
@@ -1,10 +1,11 @@
 package k8s
 
 import (
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	"strconv"
 	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // ClusterInfo identifies the cloud cluster an app is running on. Distinct from
@@ -12,7 +13,7 @@ import (
 // auth) — this carries the human/cloud-provider identifiers used in status output.
 type ClusterInfo struct {
 	Region      string `json:"region"`
-	ProjectId   string `json:"projectId"`
+	ProjectId   string `json:"projectId,omitempty"`
 	ClusterName string `json:"clusterName"`
 }
 
@@ -176,12 +177,12 @@ func AppStatusPodFromK8s(pod corev1.Pod, svcs []corev1.Service) AppStatusPod {
 }
 
 type AppStatusPodContainer struct {
-	Name         string                      `json:"name"`
-	Image        string                      `json:"image"`
-	Command      []string                    `json:"command"`
-	Ready        bool                        `json:"ready"`
-	Started      bool                        `json:"started"`
-	RestartCount int                         `json:"restartCount"`
+	Name         string   `json:"name"`
+	Image        string   `json:"image"`
+	Command      []string `json:"command"`
+	Ready        bool     `json:"ready"`
+	Started      bool     `json:"started"`
+	RestartCount int      `json:"restartCount"`
 	// LastRestartedAt is when the most recent restart occurred (the previous instance's termination time),
 	// or nil if the container has never restarted.
 	LastRestartedAt *time.Time                  `json:"lastRestartedAt"`

--- a/k8s/status_job.go
+++ b/k8s/status_job.go
@@ -1,0 +1,123 @@
+package k8s
+
+import (
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// AppStatusJobExecutionPhase mirrors the K8sJobExecutionPhase TS enum so
+// downstream consumers (Razor) can switch on the same string values.
+type AppStatusJobExecutionPhase string
+
+const (
+	JobPhaseQueued    AppStatusJobExecutionPhase = "Queued"
+	JobPhaseRunning   AppStatusJobExecutionPhase = "Running"
+	JobPhaseSucceeded AppStatusJobExecutionPhase = "Succeeded"
+	JobPhaseFailed    AppStatusJobExecutionPhase = "Failed"
+)
+
+// AppStatusJobExecution is one batchv1.Job folded into the shape Razor expects.
+// Mirrors the K8sJobExecution TS type in razor/src/models/app_status_k8s_job.ts.
+type AppStatusJobExecution struct {
+	Name        string                     `json:"name"`
+	ExecutionId string                     `json:"executionId"`
+	AppVersion  string                     `json:"appVersion,omitempty"`
+	Phase       AppStatusJobExecutionPhase `json:"phase"`
+	ScheduledAt *time.Time                 `json:"scheduledAt,omitempty"`
+	StartedAt   *time.Time                 `json:"startedAt,omitempty"`
+	CompletedAt *time.Time                 `json:"completedAt,omitempty"`
+	ExitReason  string                     `json:"exitReason,omitempty"`
+}
+
+// AppStatusJobSummary aggregates Job phases for the StatusOverview view.
+// Created is the total number of Jobs returned (i.e. all created executions).
+type AppStatusJobSummary struct {
+	Created    int `json:"created"`
+	InProgress int `json:"inProgress"`
+	Succeeded  int `json:"succeeded"`
+	Failed     int `json:"failed"`
+}
+
+// AppStatusJobExecutionFromK8s folds a single batchv1.Job into the execution
+// record. Phase is derived from conditions first, then active/succeeded/failed
+// counters as a fallback for pre-condition-set Jobs.
+func AppStatusJobExecutionFromK8s(job batchv1.Job) AppStatusJobExecution {
+	exec := AppStatusJobExecution{
+		Name:        job.Name,
+		ExecutionId: string(job.UID),
+		AppVersion:  job.Labels[StandardVersionLabel],
+		Phase:       jobPhase(job),
+		ScheduledAt: timePtr(job.CreationTimestamp.Time),
+	}
+	if job.Status.StartTime != nil {
+		exec.StartedAt = &job.Status.StartTime.Time
+	}
+	if job.Status.CompletionTime != nil {
+		exec.CompletedAt = &job.Status.CompletionTime.Time
+	}
+	// On failure, surface the condition reason ("BackoffLimitExceeded",
+	// "DeadlineExceeded", "PodFailurePolicy"...) so the UI has something to render.
+	if exec.Phase == JobPhaseFailed {
+		if c := jobCondition(job, batchv1.JobFailed); c != nil {
+			exec.ExitReason = c.Reason
+			if c.Message != "" {
+				exec.ExitReason = c.Reason + ": " + c.Message
+			}
+			if exec.CompletedAt == nil && !c.LastTransitionTime.Time.IsZero() {
+				t := c.LastTransitionTime.Time
+				exec.CompletedAt = &t
+			}
+		}
+	}
+	return exec
+}
+
+// jobPhase classifies a Job into our 4-state enum. Conditions are authoritative
+// when present; otherwise we infer from the active/succeeded counters.
+func jobPhase(job batchv1.Job) AppStatusJobExecutionPhase {
+	if c := jobCondition(job, batchv1.JobFailed); c != nil && c.Status == corev1.ConditionTrue {
+		return JobPhaseFailed
+	}
+	if c := jobCondition(job, batchv1.JobComplete); c != nil && c.Status == corev1.ConditionTrue {
+		return JobPhaseSucceeded
+	}
+	if job.Status.Active > 0 || job.Status.StartTime != nil {
+		return JobPhaseRunning
+	}
+	return JobPhaseQueued
+}
+
+func jobCondition(job batchv1.Job, t batchv1.JobConditionType) *batchv1.JobCondition {
+	for i := range job.Status.Conditions {
+		if job.Status.Conditions[i].Type == t {
+			return &job.Status.Conditions[i]
+		}
+	}
+	return nil
+}
+
+// AppStatusJobSummaryFromK8s aggregates a list of Jobs into the overview counters.
+// Created counts every Job; the others bucket by derived phase.
+func AppStatusJobSummaryFromK8s(jobs []batchv1.Job) AppStatusJobSummary {
+	summary := AppStatusJobSummary{Created: len(jobs)}
+	for _, job := range jobs {
+		switch jobPhase(job) {
+		case JobPhaseRunning, JobPhaseQueued:
+			summary.InProgress++
+		case JobPhaseSucceeded:
+			summary.Succeeded++
+		case JobPhaseFailed:
+			summary.Failed++
+		}
+	}
+	return summary
+}
+
+func timePtr(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	return &t
+}

--- a/k8s/status_job_test.go
+++ b/k8s/status_job_test.go
@@ -1,0 +1,191 @@
+package k8s
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func makeJob(name string, opts func(*batchv1.Job)) batchv1.Job {
+	job := batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			UID:  types.UID("uid-" + name),
+		},
+	}
+	if opts != nil {
+		opts(&job)
+	}
+	return job
+}
+
+func TestJobPhase(t *testing.T) {
+	cases := []struct {
+		name string
+		job  batchv1.Job
+		want AppStatusJobExecutionPhase
+	}{
+		{
+			name: "queued (no startTime, no active)",
+			job:  makeJob("j", nil),
+			want: JobPhaseQueued,
+		},
+		{
+			name: "running via active counter",
+			job: makeJob("j", func(j *batchv1.Job) {
+				j.Status.Active = 1
+			}),
+			want: JobPhaseRunning,
+		},
+		{
+			name: "running via startTime even with no active",
+			job: makeJob("j", func(j *batchv1.Job) {
+				now := metav1.Now()
+				j.Status.StartTime = &now
+			}),
+			want: JobPhaseRunning,
+		},
+		{
+			name: "succeeded via Complete=True",
+			job: makeJob("j", func(j *batchv1.Job) {
+				j.Status.Conditions = []batchv1.JobCondition{
+					{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
+				}
+			}),
+			want: JobPhaseSucceeded,
+		},
+		{
+			name: "failed via Failed=True wins over active",
+			job: makeJob("j", func(j *batchv1.Job) {
+				j.Status.Active = 1
+				j.Status.Conditions = []batchv1.JobCondition{
+					{Type: batchv1.JobFailed, Status: corev1.ConditionTrue, Reason: "BackoffLimitExceeded"},
+				}
+			}),
+			want: JobPhaseFailed,
+		},
+		{
+			name: "Complete condition with Status=False is not Succeeded",
+			job: makeJob("j", func(j *batchv1.Job) {
+				j.Status.Conditions = []batchv1.JobCondition{
+					{Type: batchv1.JobComplete, Status: corev1.ConditionFalse},
+				}
+			}),
+			want: JobPhaseQueued,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, jobPhase(tc.job))
+		})
+	}
+}
+
+func TestAppStatusJobExecutionFromK8s(t *testing.T) {
+	created := metav1.Time{Time: time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)}
+	started := metav1.Time{Time: time.Date(2026, 5, 1, 12, 0, 5, 0, time.UTC)}
+	completed := metav1.Time{Time: time.Date(2026, 5, 1, 12, 1, 0, 0, time.UTC)}
+
+	t.Run("succeeded carries timestamps", func(t *testing.T) {
+		job := batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "nightly-sync",
+				UID:               types.UID("uid-1"),
+				CreationTimestamp: created,
+				Labels:            map[string]string{StandardVersionLabel: "v1.2.3"},
+			},
+			Status: batchv1.JobStatus{
+				StartTime:      &started,
+				CompletionTime: &completed,
+				Conditions: []batchv1.JobCondition{
+					{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
+				},
+			},
+		}
+		got := AppStatusJobExecutionFromK8s(job)
+		assert.Equal(t, "nightly-sync", got.Name)
+		assert.Equal(t, "uid-1", got.ExecutionId)
+		assert.Equal(t, "v1.2.3", got.AppVersion)
+		assert.Equal(t, JobPhaseSucceeded, got.Phase)
+		require.NotNil(t, got.ScheduledAt)
+		assert.Equal(t, created.Time, *got.ScheduledAt)
+		require.NotNil(t, got.StartedAt)
+		assert.Equal(t, started.Time, *got.StartedAt)
+		require.NotNil(t, got.CompletedAt)
+		assert.Equal(t, completed.Time, *got.CompletedAt)
+		assert.Empty(t, got.ExitReason)
+	})
+
+	t.Run("failed surfaces condition reason+message", func(t *testing.T) {
+		failedAt := metav1.Time{Time: time.Date(2026, 5, 1, 12, 5, 0, 0, time.UTC)}
+		job := batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "broken-job", UID: types.UID("uid-2"), CreationTimestamp: created},
+			Status: batchv1.JobStatus{
+				StartTime: &started,
+				Conditions: []batchv1.JobCondition{{
+					Type:               batchv1.JobFailed,
+					Status:             corev1.ConditionTrue,
+					Reason:             "BackoffLimitExceeded",
+					Message:            "Job has reached the specified backoff limit",
+					LastTransitionTime: failedAt,
+				}},
+			},
+		}
+		got := AppStatusJobExecutionFromK8s(job)
+		assert.Equal(t, JobPhaseFailed, got.Phase)
+		assert.Equal(t, "BackoffLimitExceeded: Job has reached the specified backoff limit", got.ExitReason)
+		// CompletionTime is unset for failed Jobs; we fall back to the failure transition time.
+		require.NotNil(t, got.CompletedAt)
+		assert.Equal(t, failedAt.Time, *got.CompletedAt)
+	})
+
+	t.Run("queued has only ScheduledAt", func(t *testing.T) {
+		job := batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "pending-job", UID: types.UID("uid-3"), CreationTimestamp: created},
+		}
+		got := AppStatusJobExecutionFromK8s(job)
+		assert.Equal(t, JobPhaseQueued, got.Phase)
+		require.NotNil(t, got.ScheduledAt)
+		assert.Nil(t, got.StartedAt)
+		assert.Nil(t, got.CompletedAt)
+	})
+}
+
+func TestAppStatusJobSummaryFromK8s(t *testing.T) {
+	now := metav1.Now()
+	jobs := []batchv1.Job{
+		// queued
+		makeJob("a", nil),
+		// running
+		makeJob("b", func(j *batchv1.Job) { j.Status.Active = 1 }),
+		// succeeded
+		makeJob("c", func(j *batchv1.Job) {
+			j.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}}
+		}),
+		makeJob("d", func(j *batchv1.Job) {
+			j.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}}
+		}),
+		// failed
+		makeJob("e", func(j *batchv1.Job) {
+			j.Status.StartTime = &now
+			j.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobFailed, Status: corev1.ConditionTrue}}
+		}),
+	}
+	summary := AppStatusJobSummaryFromK8s(jobs)
+	assert.Equal(t, 5, summary.Created)
+	assert.Equal(t, 2, summary.InProgress) // queued + running
+	assert.Equal(t, 2, summary.Succeeded)
+	assert.Equal(t, 1, summary.Failed)
+}
+
+func TestAppStatusJobSummaryFromK8s_Empty(t *testing.T) {
+	summary := AppStatusJobSummaryFromK8s(nil)
+	assert.Equal(t, AppStatusJobSummary{}, summary)
+}

--- a/k8s/status_overview.go
+++ b/k8s/status_overview.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"github.com/nullstone-io/deployment-sdk/app"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"strconv"
 	"time"
 )
@@ -24,18 +25,19 @@ func (a AppStatusOverview) GetDeploymentVersions() []string {
 }
 
 type AppStatusOverviewReplicaSet struct {
-	Name              string    `json:"name"`
-	Revision          int       `json:"revision"`
-	Generation        int64     `json:"generation"`
-	AppVersion        string    `json:"appVersion"`
-	CreatedAt         time.Time `json:"createdAt"`
-	DesiredReplicas   int       `json:"desiredReplicas"`
-	AvailableReplicas int       `json:"availableReplicas"`
-	ReadyReplicas     int       `json:"readyReplicas"`
-	Replicas          int       `json:"replicas"`
+	Name              string                    `json:"name"`
+	Revision          int                       `json:"revision"`
+	Generation        int64                     `json:"generation"`
+	AppVersion        string                    `json:"appVersion"`
+	CreatedAt         time.Time                 `json:"createdAt"`
+	DesiredReplicas   int                       `json:"desiredReplicas"`
+	AvailableReplicas int                       `json:"availableReplicas"`
+	ReadyReplicas     int                       `json:"readyReplicas"`
+	Replicas          int                       `json:"replicas"`
+	Ports             []AppStatusReplicaSetPort `json:"ports"`
 }
 
-func AppStatusOverviewReplicaSetFromK8s(rs appsv1.ReplicaSet) AppStatusOverviewReplicaSet {
+func AppStatusOverviewReplicaSetFromK8s(rs appsv1.ReplicaSet, svcs []corev1.Service) AppStatusOverviewReplicaSet {
 	desired := 0
 	if val, err := strconv.Atoi(rs.Annotations["deployment.kubernetes.io/desired-replicas"]); err == nil {
 		desired = val
@@ -51,5 +53,6 @@ func AppStatusOverviewReplicaSetFromK8s(rs appsv1.ReplicaSet) AppStatusOverviewR
 		AvailableReplicas: int(rs.Status.AvailableReplicas),
 		ReadyReplicas:     int(rs.Status.ReadyReplicas),
 		Replicas:          int(rs.Status.Replicas),
+		Ports:             AggregateReplicaSetPorts(rs, svcs),
 	}
 }

--- a/k8s/status_overview.go
+++ b/k8s/status_overview.go
@@ -17,6 +17,7 @@ type AppStatusOverview struct {
 	Namespace      string                        `json:"namespace"`
 	DeploymentName string                        `json:"deploymentName"`
 	ReplicaSets    []AppStatusOverviewReplicaSet `json:"replicaSets"`
+	Jobs           AppStatusJobSummary           `json:"jobs"`
 }
 
 func (a AppStatusOverview) GetDeploymentVersions() []string {

--- a/k8s/status_overview.go
+++ b/k8s/status_overview.go
@@ -13,7 +13,10 @@ var (
 )
 
 type AppStatusOverview struct {
-	ReplicaSets []AppStatusOverviewReplicaSet `json:"replicaSets"`
+	Cluster        ClusterInfo                   `json:"cluster"`
+	Namespace      string                        `json:"namespace"`
+	DeploymentName string                        `json:"deploymentName"`
+	ReplicaSets    []AppStatusOverviewReplicaSet `json:"replicaSets"`
 }
 
 func (a AppStatusOverview) GetDeploymentVersions() []string {

--- a/k8s/statuser.go
+++ b/k8s/statuser.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/nullstone-io/deployment-sdk/app"
 	"github.com/nullstone-io/deployment-sdk/logging"
-	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -126,9 +126,6 @@ func (s *Statuser) Status(ctx context.Context) (any, error) {
 	}
 
 	st.DeploymentName = findDeploymentNameFromReplicaSets(s.replicaSets)
-	for _, job := range s.jobs {
-		st.Jobs = append(st.Jobs, AppStatusJobExecutionFromK8s(job))
-	}
 
 	statusPods := make(AppStatusPods, 0, len(s.pods))
 	for _, pod := range s.pods {
@@ -138,6 +135,10 @@ func (s *Statuser) Status(ctx context.Context) (any, error) {
 		revision := AppStatusReplicaSetFromK8s(replicaSet, s.services)
 		revision.Pods = statusPods.ListByReplicaSet(revision.Name)
 		st.ReplicaSets = append(st.ReplicaSets, revision)
+	}
+
+	for _, job := range s.jobs {
+		st.Jobs = append(st.Jobs, AppStatusJobExecutionFromK8s(job))
 	}
 	return st, nil
 }

--- a/k8s/statuser.go
+++ b/k8s/statuser.go
@@ -3,10 +3,13 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/nullstone-io/deployment-sdk/app"
 	"github.com/nullstone-io/deployment-sdk/logging"
+	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -14,6 +17,11 @@ import (
 
 type NewConfiger func(ctx context.Context) (*rest.Config, error)
 
+// Statuser produces AppStatus and AppStatusOverview for a Nullstone app.
+//
+// Methods use pointer receivers so a single Statuser instance can cache the
+// loaded k8s resources across calls — calling both Status and StatusOverview
+// on the same instance reuses one set of API List requests.
 type Statuser struct {
 	OsWriters    logging.OsWriters
 	Details      app.Details
@@ -21,9 +29,68 @@ type Statuser struct {
 	AppNamespace string
 	AppName      string
 	NewConfigFn  NewConfiger
+
+	// Cache populated by initialize. Guarded by initOnce.
+	initOnce    sync.Once
+	initErr     error
+	client      *kubernetes.Clientset
+	replicaSets []v1.ReplicaSet
+	services    []corev1.Service
+	pods        []corev1.Pod
+	jobs        []batchv1.Job
 }
 
-func (s Statuser) StatusOverview(ctx context.Context) (app.StatusOverviewResult, error) {
+// initialize lazily fetches every k8s resource Status and StatusOverview need.
+// It runs at most once per Statuser; the cached error (if any) is returned on
+// subsequent calls so partial state doesn't get reused.
+func (s *Statuser) initialize(ctx context.Context) error {
+	s.initOnce.Do(func() {
+		s.initErr = s.loadResources(ctx)
+	})
+	return s.initErr
+}
+
+func (s *Statuser) loadResources(ctx context.Context) error {
+	cfg, err := s.NewConfigFn(ctx)
+	if err != nil {
+		return fmt.Errorf("error creating kubernetes client: %w", err)
+	}
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("error initializing kubernetes client: %w", err)
+	}
+	s.client = client
+
+	listOpts := metav1.ListOptions{LabelSelector: fmt.Sprintf("nullstone.io/app=%s", s.AppName)}
+
+	rsResp, err := client.AppsV1().ReplicaSets(s.AppNamespace).List(ctx, listOpts)
+	if err != nil {
+		return fmt.Errorf("error retrieving app replica sets: %w", err)
+	}
+	s.replicaSets = rsResp.Items
+
+	svcResp, err := client.CoreV1().Services(s.AppNamespace).List(ctx, listOpts)
+	if err != nil {
+		return fmt.Errorf("error retrieving app services: %w", err)
+	}
+	s.services = svcResp.Items
+
+	podResp, err := client.CoreV1().Pods(s.AppNamespace).List(ctx, listOpts)
+	if err != nil {
+		return fmt.Errorf("error retrieving app pods: %w", err)
+	}
+	s.pods = podResp.Items
+
+	jobResp, err := client.BatchV1().Jobs(s.AppNamespace).List(ctx, listOpts)
+	if err != nil {
+		return fmt.Errorf("error retrieving app jobs: %w", err)
+	}
+	s.jobs = jobResp.Items
+
+	return nil
+}
+
+func (s *Statuser) StatusOverview(ctx context.Context) (app.StatusOverviewResult, error) {
 	so := AppStatusOverview{
 		Cluster:     s.Cluster,
 		Namespace:   s.AppNamespace,
@@ -32,91 +99,46 @@ func (s Statuser) StatusOverview(ctx context.Context) (app.StatusOverviewResult,
 	if s.AppName == "" {
 		return so, nil
 	}
-
-	cfg, err := s.NewConfigFn(ctx)
-	if err != nil {
-		return so, fmt.Errorf("error creating kubernetes client: %w", err)
-	}
-	client, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		return so, fmt.Errorf("error initializing kubernetes client: %w", err)
+	if err := s.initialize(ctx); err != nil {
+		return so, err
 	}
 
-	appLabel := fmt.Sprintf("nullstone.io/app=%s", s.AppName)
-	replicaSetsResponse, err := client.AppsV1().ReplicaSets(s.AppNamespace).List(ctx, metav1.ListOptions{LabelSelector: appLabel})
-	if err != nil {
-		return so, fmt.Errorf("error retrieving app replica sets: %w", err)
-	}
-	svcsResponse, err := client.CoreV1().Services(s.AppNamespace).List(ctx, metav1.ListOptions{LabelSelector: appLabel})
-	if err != nil {
-		return so, fmt.Errorf("error retrieving app services: %w", err)
-	}
-	jobsResponse, err := client.BatchV1().Jobs(s.AppNamespace).List(ctx, metav1.ListOptions{LabelSelector: appLabel})
-	if err != nil {
-		return so, fmt.Errorf("error retrieving app jobs: %w", err)
-	}
-	so.Jobs = AppStatusJobSummaryFromK8s(jobsResponse.Items)
-	so.DeploymentName = findDeploymentNameFromReplicaSets(replicaSetsResponse.Items)
-	replicaSets := ExcludeOldReplicaSets(replicaSetsResponse.Items)
-	for _, replicaSet := range replicaSets {
-		revision := AppStatusOverviewReplicaSetFromK8s(replicaSet, svcsResponse.Items)
-		so.ReplicaSets = append(so.ReplicaSets, revision)
+	so.DeploymentName = findDeploymentNameFromReplicaSets(s.replicaSets)
+	so.Jobs = AppStatusJobSummaryFromK8s(s.jobs)
+	for _, replicaSet := range ExcludeOldReplicaSets(s.replicaSets) {
+		so.ReplicaSets = append(so.ReplicaSets, AppStatusOverviewReplicaSetFromK8s(replicaSet, s.services))
 	}
 	return so, nil
 }
 
-func (s Statuser) Status(ctx context.Context) (any, error) {
+func (s *Statuser) Status(ctx context.Context) (any, error) {
 	st := AppStatus{
 		Cluster:     s.Cluster,
 		Namespace:   s.AppNamespace,
 		ReplicaSets: make([]AppStatusReplicaSet, 0),
+		Jobs:        make([]AppStatusJobExecution, 0),
 	}
 	if s.AppName == "" {
 		return st, nil
 	}
-
-	cfg, err := s.NewConfigFn(ctx)
-	if err != nil {
-		return st, fmt.Errorf("error creating kubernetes client: %w", err)
-	}
-	client, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		return st, fmt.Errorf("error initializing kubernetes client: %w", err)
+	if err := s.initialize(ctx); err != nil {
+		return st, err
 	}
 
-	appLabel := fmt.Sprintf("nullstone.io/app=%s", s.AppName)
-	replicaSetsResponse, err := client.AppsV1().ReplicaSets(s.AppNamespace).List(ctx, metav1.ListOptions{LabelSelector: appLabel})
-	if err != nil {
-		return st, fmt.Errorf("error retrieving app replica sets: %w", err)
-	}
-	svcsResponse, err := client.CoreV1().Services(s.AppNamespace).List(ctx, metav1.ListOptions{LabelSelector: appLabel})
-	if err != nil {
-		return st, fmt.Errorf("error retrieving app services: %w", err)
-	}
-	podsResponse, err := client.CoreV1().Pods(s.AppNamespace).List(ctx, metav1.ListOptions{LabelSelector: appLabel})
-	if err != nil {
-		return st, fmt.Errorf("error retrieving app pods: %w", err)
-	}
-	jobsResponse, err := client.BatchV1().Jobs(s.AppNamespace).List(ctx, metav1.ListOptions{LabelSelector: appLabel})
-	if err != nil {
-		return st, fmt.Errorf("error retrieving app jobs: %w", err)
-	}
-	st.Jobs = make([]AppStatusJobExecution, 0, len(jobsResponse.Items))
-	for _, job := range jobsResponse.Items {
+	st.DeploymentName = findDeploymentNameFromReplicaSets(s.replicaSets)
+	for _, job := range s.jobs {
 		st.Jobs = append(st.Jobs, AppStatusJobExecutionFromK8s(job))
 	}
-	statusPods := make(AppStatusPods, 0)
-	for _, pod := range podsResponse.Items {
-		statusPods = append(statusPods, AppStatusPodFromK8s(pod, svcsResponse.Items))
+
+	statusPods := make(AppStatusPods, 0, len(s.pods))
+	for _, pod := range s.pods {
+		statusPods = append(statusPods, AppStatusPodFromK8s(pod, s.services))
 	}
-	st.DeploymentName = findDeploymentNameFromReplicaSets(replicaSetsResponse.Items)
-	replicaSets := ExcludeOldReplicaSets(replicaSetsResponse.Items)
-	for _, replicaSet := range replicaSets {
-		revision := AppStatusReplicaSetFromK8s(replicaSet, svcsResponse.Items)
+	for _, replicaSet := range ExcludeOldReplicaSets(s.replicaSets) {
+		revision := AppStatusReplicaSetFromK8s(replicaSet, s.services)
 		revision.Pods = statusPods.ListByReplicaSet(revision.Name)
 		st.ReplicaSets = append(st.ReplicaSets, revision)
 	}
-
 	return st, nil
 }
 

--- a/k8s/statuser.go
+++ b/k8s/statuser.go
@@ -42,9 +42,13 @@ func (s Statuser) StatusOverview(ctx context.Context) (app.StatusOverviewResult,
 	if err != nil {
 		return so, fmt.Errorf("error retrieving app replica sets: %w", err)
 	}
+	svcsResponse, err := client.CoreV1().Services(s.AppNamespace).List(ctx, metav1.ListOptions{LabelSelector: appLabel})
+	if err != nil {
+		return so, fmt.Errorf("error retrieving app services: %w", err)
+	}
 	replicaSets := ExcludeOldReplicaSets(replicaSetsResponse.Items)
 	for _, replicaSet := range replicaSets {
-		revision := AppStatusOverviewReplicaSetFromK8s(replicaSet)
+		revision := AppStatusOverviewReplicaSetFromK8s(replicaSet, svcsResponse.Items)
 		so.ReplicaSets = append(so.ReplicaSets, revision)
 	}
 	return so, nil
@@ -84,7 +88,7 @@ func (s Statuser) Status(ctx context.Context) (any, error) {
 	}
 	replicaSets := ExcludeOldReplicaSets(replicaSetsResponse.Items)
 	for _, replicaSet := range replicaSets {
-		revision := AppStatusReplicaSetFromK8s(replicaSet)
+		revision := AppStatusReplicaSetFromK8s(replicaSet, svcsResponse.Items)
 		revision.Pods = statusPods.ListByReplicaSet(revision.Name)
 		st.ReplicaSets = append(st.ReplicaSets, revision)
 	}

--- a/k8s/statuser.go
+++ b/k8s/statuser.go
@@ -17,13 +17,18 @@ type NewConfiger func(ctx context.Context) (*rest.Config, error)
 type Statuser struct {
 	OsWriters    logging.OsWriters
 	Details      app.Details
+	Cluster      ClusterInfo
 	AppNamespace string
 	AppName      string
 	NewConfigFn  NewConfiger
 }
 
 func (s Statuser) StatusOverview(ctx context.Context) (app.StatusOverviewResult, error) {
-	so := AppStatusOverview{ReplicaSets: make([]AppStatusOverviewReplicaSet, 0)}
+	so := AppStatusOverview{
+		Cluster:     s.Cluster,
+		Namespace:   s.AppNamespace,
+		ReplicaSets: make([]AppStatusOverviewReplicaSet, 0),
+	}
 	if s.AppName == "" {
 		return so, nil
 	}
@@ -46,6 +51,7 @@ func (s Statuser) StatusOverview(ctx context.Context) (app.StatusOverviewResult,
 	if err != nil {
 		return so, fmt.Errorf("error retrieving app services: %w", err)
 	}
+	so.DeploymentName = findDeploymentNameFromReplicaSets(replicaSetsResponse.Items)
 	replicaSets := ExcludeOldReplicaSets(replicaSetsResponse.Items)
 	for _, replicaSet := range replicaSets {
 		revision := AppStatusOverviewReplicaSetFromK8s(replicaSet, svcsResponse.Items)
@@ -55,7 +61,11 @@ func (s Statuser) StatusOverview(ctx context.Context) (app.StatusOverviewResult,
 }
 
 func (s Statuser) Status(ctx context.Context) (any, error) {
-	st := AppStatus{ReplicaSets: make([]AppStatusReplicaSet, 0)}
+	st := AppStatus{
+		Cluster:     s.Cluster,
+		Namespace:   s.AppNamespace,
+		ReplicaSets: make([]AppStatusReplicaSet, 0),
+	}
 	if s.AppName == "" {
 		return st, nil
 	}
@@ -86,6 +96,7 @@ func (s Statuser) Status(ctx context.Context) (any, error) {
 	for _, pod := range podsResponse.Items {
 		statusPods = append(statusPods, AppStatusPodFromK8s(pod, svcsResponse.Items))
 	}
+	st.DeploymentName = findDeploymentNameFromReplicaSets(replicaSetsResponse.Items)
 	replicaSets := ExcludeOldReplicaSets(replicaSetsResponse.Items)
 	for _, replicaSet := range replicaSets {
 		revision := AppStatusReplicaSetFromK8s(replicaSet, svcsResponse.Items)
@@ -94,6 +105,21 @@ func (s Statuser) Status(ctx context.Context) (any, error) {
 	}
 
 	return st, nil
+}
+
+// findDeploymentNameFromReplicaSets returns the name of the Deployment that
+// owns one of the given ReplicaSets, or "" if none of them are Deployment-owned.
+// Long-running services run under a Deployment; jobs and one-shot tasks don't,
+// so an empty string is the correct signal that this app isn't a service.
+func findDeploymentNameFromReplicaSets(rss []v1.ReplicaSet) string {
+	for _, rs := range rss {
+		for _, or := range rs.OwnerReferences {
+			if or.Kind == "Deployment" {
+				return or.Name
+			}
+		}
+	}
+	return ""
 }
 
 // ExcludeOldReplicaSets filters out old replica sets

--- a/k8s/statuser.go
+++ b/k8s/statuser.go
@@ -51,6 +51,11 @@ func (s Statuser) StatusOverview(ctx context.Context) (app.StatusOverviewResult,
 	if err != nil {
 		return so, fmt.Errorf("error retrieving app services: %w", err)
 	}
+	jobsResponse, err := client.BatchV1().Jobs(s.AppNamespace).List(ctx, metav1.ListOptions{LabelSelector: appLabel})
+	if err != nil {
+		return so, fmt.Errorf("error retrieving app jobs: %w", err)
+	}
+	so.Jobs = AppStatusJobSummaryFromK8s(jobsResponse.Items)
 	so.DeploymentName = findDeploymentNameFromReplicaSets(replicaSetsResponse.Items)
 	replicaSets := ExcludeOldReplicaSets(replicaSetsResponse.Items)
 	for _, replicaSet := range replicaSets {
@@ -91,6 +96,14 @@ func (s Statuser) Status(ctx context.Context) (any, error) {
 	podsResponse, err := client.CoreV1().Pods(s.AppNamespace).List(ctx, metav1.ListOptions{LabelSelector: appLabel})
 	if err != nil {
 		return st, fmt.Errorf("error retrieving app pods: %w", err)
+	}
+	jobsResponse, err := client.BatchV1().Jobs(s.AppNamespace).List(ctx, metav1.ListOptions{LabelSelector: appLabel})
+	if err != nil {
+		return st, fmt.Errorf("error retrieving app jobs: %w", err)
+	}
+	st.Jobs = make([]AppStatusJobExecution, 0, len(jobsResponse.Items))
+	for _, job := range jobsResponse.Items {
+		st.Jobs = append(st.Jobs, AppStatusJobExecutionFromK8s(job))
 	}
 	statusPods := make(AppStatusPods, 0)
 	for _, pod := range podsResponse.Items {


### PR DESCRIPTION
This adds info to the k8s Statuser needed to provide context actions and additional information related to the status of a k8s app.

#### App Status
- `cluster` -> region, cluster name, project id (if gcp)
- `namespace`
- `deploymentName` (if job, empty)
- `jobs` - history and details for each job

#### Replica Set
- port mappings
- max restart count
- last restarted at

#### Pod
- max restart count
- last restarted at

#### Container
- name
- image
- command
- restart count
- last restarted at