### PR TITLE
Feat/26/k8s failure modes

### DIFF
--- a/app/log_streamer.go
+++ b/app/log_streamer.go
@@ -25,7 +25,10 @@ type LogStreamOptions struct {
 
 	// A filter to apply when querying the log source
 	// For Kubernetes, this is a label selector to further filter down the logs
-	Selector *string
+	Selectors []string
+
+	// A filter to apply when querying a Kubernetes log source for a single pod
+	Pod string
 
 	// WatchInterval dictates how often the log streamer will query AWS for new events
 	// If left unspecified or 0, will use default watch interval of 1s

--- a/gcp/cloudlogging/log_streamer.go
+++ b/gcp/cloudlogging/log_streamer.go
@@ -92,7 +92,7 @@ func (s LogStreamer) Stream(ctx context.Context, options app.LogStreamOptions) e
 
 func (s LogStreamer) writeLatestEventsFunc(filter string, options app.LogStreamOptions) func(ctx context.Context, client *logadmin.Client) error {
 	startTime := options.StartTime
-	selector := options.Selector
+	selectors := options.Selectors
 	var lastEventTime *time.Time
 	visitedSpans := map[string]bool{}
 
@@ -100,7 +100,7 @@ func (s LogStreamer) writeLatestEventsFunc(filter string, options app.LogStreamO
 		if lastEventTime != nil {
 			startTime = lastEventTime
 		}
-		it := client.Entries(ctx, logadmin.Filter(buildFilter(filter, selector, startTime, options.EndTime)))
+		it := client.Entries(ctx, logadmin.Filter(buildFilter(filter, selectors, startTime, options.EndTime)))
 		for {
 			select {
 			case <-ctx.Done():
@@ -125,11 +125,9 @@ func (s LogStreamer) writeLatestEventsFunc(filter string, options app.LogStreamO
 	}
 }
 
-func buildFilter(initialFilter string, selector *string, startTime *time.Time, endTime *time.Time) string {
+func buildFilter(initialFilter string, selectors []string, startTime *time.Time, endTime *time.Time) string {
 	filters := []string{fmt.Sprintf("(%s)", initialFilter)}
-	if selector != nil {
-		filters = append(filters, *selector)
-	}
+	filters = append(filters, selectors...)
 	if startTime != nil {
 		filters = append(filters, fmt.Sprintf("timestamp >= %q", startTime.Format(time.RFC3339)))
 	}

--- a/k8s/deploy_event.go
+++ b/k8s/deploy_event.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"bytes"
 	"github.com/nullstone-io/deployment-sdk/display"
+	"github.com/nullstone-io/deployment-sdk/k8s/failures"
 	"strings"
 	"time"
 )
@@ -19,6 +20,9 @@ type DeployEvent struct {
 	Reason    string
 	Object    string
 	Message   string
+	// Failure is the classified failure for this event, if the raw event matched
+	// a catalog entry. Nil for events that don't classify (most Normal events).
+	Failure *failures.Failure
 }
 
 func (e DeployEvent) String() string {
@@ -32,6 +36,12 @@ func (e DeployEvent) String() string {
 	if e.Reason != "" {
 		buf.WriteString("(")
 		buf.WriteString(e.Reason)
+		// Render the classified canonical name when it adds information beyond
+		// the raw reason — e.g. (Unhealthy → LivenessProbeFailed).
+		if e.Failure != nil && e.Failure.Name != "" && e.Failure.Name != e.Reason {
+			buf.WriteString(" → ")
+			buf.WriteString(e.Failure.Name)
+		}
 		buf.WriteString(") ")
 	}
 	if e.Type == EventTypeWarning {

--- a/k8s/deploy_event_test.go
+++ b/k8s/deploy_event_test.go
@@ -1,0 +1,60 @@
+package k8s
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nullstone-io/deployment-sdk/k8s/failures"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeployEvent_String_Classified(t *testing.T) {
+	ts := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	t.Run("classified failure renders canonical name next to reason", func(t *testing.T) {
+		de := DeployEvent{
+			Timestamp: ts,
+			Type:      EventTypeWarning,
+			Reason:    "Unhealthy",
+			Object:    "pod/foo",
+			Message:   "Liveness probe failed: HTTP 500",
+			Failure: &failures.Failure{
+				Name:     "LivenessProbeFailed",
+				Category: failures.CategoryRuntime,
+			},
+		}
+		out := de.String()
+		assert.Contains(t, out, "(Unhealthy → LivenessProbeFailed)")
+		assert.Contains(t, out, "Liveness probe failed: HTTP 500")
+	})
+
+	t.Run("matching reason is not duplicated", func(t *testing.T) {
+		de := DeployEvent{
+			Timestamp: ts,
+			Type:      EventTypeWarning,
+			Reason:    "FailedScheduling",
+			Object:    "pod/foo",
+			Message:   "0/3 nodes",
+			Failure: &failures.Failure{
+				Name: "FailedScheduling", // same as Reason
+			},
+		}
+		out := de.String()
+		assert.Contains(t, out, "(FailedScheduling)")
+		assert.False(t, strings.Contains(out, "→"), "expected no arrow when classified name == raw reason; got %q", out)
+	})
+
+	t.Run("unclassified event renders without arrow", func(t *testing.T) {
+		de := DeployEvent{
+			Timestamp: ts,
+			Type:      EventTypeNormal,
+			Reason:    "Pulled",
+			Object:    "pod/foo",
+			Message:   "Container image pulled",
+		}
+		out := de.String()
+		assert.Contains(t, out, "(Pulled)")
+		assert.False(t, strings.Contains(out, "→"))
+	})
+}

--- a/k8s/deploy_watcher.go
+++ b/k8s/deploy_watcher.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/mitchellh/colorstring"
 	"github.com/nullstone-io/deployment-sdk/app"
+	"github.com/nullstone-io/deployment-sdk/k8s/failures"
 	"github.com/nullstone-io/deployment-sdk/logging"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -270,11 +271,19 @@ func (w *DeployWatcher) emitEvent(ctx context.Context, earliest time.Time, event
 		return
 	}
 	obj := fmt.Sprintf("%s/%s", strings.ToLower(event.InvolvedObject.Kind), event.InvolvedObject.Name)
-	colorstring.Fprintln(stdout, DeployEvent{
+	de := DeployEvent{
 		Timestamp: event.LastTimestamp.Time,
 		Type:      event.Type,
 		Reason:    event.Reason,
 		Object:    obj,
 		Message:   event.Message,
-	}.String())
+		Failure:   failures.ClassifyEvent(event),
+	}
+	// Promote informational events to Warning when classification reveals an
+	// actionable failure the raw event Type didn't flag (e.g. probe failures
+	// arrive as Normal/Warning depending on K8s version).
+	if de.Failure != nil && de.Type == EventTypeNormal {
+		de.Type = EventTypeWarning
+	}
+	colorstring.Fprintln(stdout, de.String())
 }

--- a/k8s/failure-modes.md
+++ b/k8s/failure-modes.md
@@ -1,0 +1,879 @@
+# Kubernetes Deployment Failure Modes
+
+Catalog deliverable for [NUL-26](https://linear.app/nullstone/issue/NUL-26/enumerate-kubernetes-deployment-failure-modes-and-improve-deployment).
+This document is the **Phase 1** enumeration. Phase 2 (regression tests) and Phase 3 (log-pipeline changes) consume it.
+
+Scope: generic Kubernetes plus provider-specific modes on **GKE**, **EKS**, **AKS**.
+
+## How to read an entry
+
+Each entry follows this schema (from NUL-26):
+
+- **Manifestation** — concrete k8s signals: event `reason`, pod phase/conditions, container state reasons, Deployment/ReplicaSet conditions, status fields.
+- **Root cause** — what the user did wrong.
+- **Detection heuristic** — precise API fields / event-message substrings a watcher should match.
+- **Report to user** — canonical name, remediation hint, offending object identifiers.
+- **Docs** — authoritative links.
+- **Scope** — generic / GKE / EKS / AKS.
+
+Provider scope tags: `generic`, `gke`, `eks`, `aks`. Multiple tags allowed.
+
+---
+
+## Current Nullstone coverage (baseline)
+
+Reference points for where this catalog plugs into today's code. Verify before building on these claims — file/line references drift.
+
+| Already detected | Location |
+|---|---|
+| Deployment `ProgressDeadlineExceeded` timeout | `check_deployment.go` — `DeploymentProgressing` condition with `TimedOutReason` |
+| Deployment deleted mid-watch | `deploy_watcher.go` |
+| Superseding revision (higher `.metadata.generation`) | `deploy_watcher.go` |
+| Pod terminal phase (`PodFailed`, `PodSucceeded`) stops log stream | `logs/workload_streamer.go` |
+| Incomplete rollout (`updatedReplicas` / `availableReplicas` < desired) | `check_deployment.go` |
+| Raw namespace event stream (all `Reason`s forwarded as-is) | `deploy_watcher.go` |
+| Service endpoint ready/not-ready transitions | `service_watcher.go` |
+
+**Structural gaps the catalog must close:**
+
+1. Container-level `state.waiting.reason` / `state.terminated.reason` are received in `ContainerStatus` but never parsed into a canonical failure name. Users see raw events, not a diagnosis.
+2. Probe failures are forwarded as generic `Unhealthy` events without being labeled as readiness / liveness / startup.
+3. `Deployment.status.conditions[type=ReplicaFailure]` is not surfaced — quota, admission-webhook, and PSA denials are silent until the progress deadline fires.
+4. No provider-specific discriminators on event messages (EKS/GKE/AKS). Provider deployers (`aws/eks`, `gcp/gke`, `azure/aks`) all share the generic `k8s.Deployer` and add nothing beyond kubeconfig/auth.
+5. No cross-object checks (referenced ConfigMap/Secret/SA/PVC existence, IngressClass presence, PodSecurity namespace labels).
+
+---
+
+## Detection strategy (top-down)
+
+A deployment watcher should layer checks in this order. The catalog entries below slot into this pipeline.
+
+1. **Deployment-level signal**
+   - `status.conditions[type=Progressing,status=False,reason=ProgressDeadlineExceeded]` → rollout failed; drill down.
+   - `status.conditions[type=ReplicaFailure,status=True]` → child create blocked (quota / admission / RBAC / PSA). Read condition message.
+   - `availableReplicas < spec.replicas` past deadline → degraded.
+2. **ReplicaSet-level** (newest RS, highest `deployment.kubernetes.io/revision`)
+   - Events with `reason=FailedCreate` carry admission / quota details.
+3. **Pod-level triage** (pods owned by newest RS)
+   - `status.phase` = `Pending` → check `conditions[type=PodScheduled]`:
+     - `False, reason=Unschedulable` → **Scheduling** bucket (parse event message).
+     - `False, reason=SchedulingGated` → external gate controller hasn't cleared.
+     - `True` but `Initialized=False` → **Volumes / init containers**.
+     - `Initialized=True` but `ContainersReady=False` → **Image / probes**.
+   - `containerStatuses[].state.waiting.reason` drives the bucket.
+   - `containerStatuses[].lastState.terminated.{reason,exitCode}` classifies CrashLoopBackOff causes.
+   - `status.reason=Evicted` → node pressure; parse message.
+4. **Event bus** per pod — `kubectl get events --field-selector involvedObject.kind=Pod,involvedObject.name=X`. Bucket by `reason`; classify with `message` substrings.
+5. **Cross-object validation** (optional, disambiguates ambiguous signals)
+   - Referenced ConfigMap / Secret / SA / PVC / IngressClass exist.
+   - ServiceAccount carries expected annotations (IRSA / WI / ACR pull).
+   - PodSecurity namespace labels vs pod spec.
+6. **Provider discriminators** on event messages — see §8–§10.
+
+### Quick cheat sheet
+
+| Signal | Bucket |
+|---|---|
+| `state.waiting.reason` ∈ {`ImagePullBackOff`, `ErrImagePull`, `InvalidImageName`, `ErrImageNeverPull`, `ImageInspectError`} | Image (§1) |
+| `state.waiting.reason=CrashLoopBackOff` + `lastState.terminated.reason=OOMKilled` | OOM (§2.2) |
+| `state.waiting.reason=CrashLoopBackOff` + other exitCode | App crash (§2.1) |
+| `state.waiting.reason=CreateContainerConfigError` | Config missing (§2.4) |
+| `state.waiting.reason` ∈ {`CreateContainerError`, `RunContainerError`} | Runtime config (§2.5–2.6) |
+| `conditions[PodScheduled]=False, reason=Unschedulable` | Scheduling (§3) |
+| `conditions[PodScheduled]=False, reason=SchedulingGated` | Scheduling gate (§3.6) |
+| Event `FailedMount` / `FailedAttachVolume` | Storage (§4) |
+| Event `FailedCreatePodSandBox` | CNI / IPAM (§5.1) |
+| Event `Unhealthy` | Probes (§2.3) |
+| Event `BackOff` | Restart loop (pair with `lastState`) |
+| `status.reason=Evicted` | Node pressure (§11.2) |
+| Event `Preempted` | Priority preemption (§11.3) |
+| Deployment `ReplicaFailure=True` | Quota / admission / webhook / PSA (§6) |
+| Deployment `Progressing=False, reason=ProgressDeadlineExceeded` | Top-level rollout timeout (§7.1) |
+| PDB `disruptionsAllowed=0` during rollout | PDB block (§3.5) |
+| `readinessGates[].status != True` | External gate (§7.8) |
+
+---
+
+## 1. Image / Registry
+
+### 1.1 ImagePullBackOff / ErrImagePull
+
+- **Manifestation**: Pod `Pending`. `containerStatuses[].state.waiting.reason` cycles `ErrImagePull` → `ImagePullBackOff`. Events: `reason=Failed`, message contains one of:
+  - `unauthorized`, `authentication required`, `denied` — auth failure.
+  - `manifest unknown`, `not found`, `repository ... not found` — missing tag/repo.
+  - `toomanyrequests`, `rate limit` — Docker Hub throttling.
+  - `no such host`, `i/o timeout`, `connection refused` — network/DNS.
+- **Root cause**: wrong tag/digest; private registry without `imagePullSecrets`; expired creds; registry unreachable; anonymous-pull rate limit.
+- **Detection**: `state.waiting.reason ∈ {"ErrImagePull","ImagePullBackOff"}`. Subclassify via event message.
+- **Report**: `ImagePullBackOff` with sub-reason (`auth`, `not-found`, `rate-limit`, `network`). Include `namespace/pod`, container name, image reference, and the offending event message.
+- **Remediation**: verify the tag exists in the registry; attach a valid `imagePullSecret`; for Docker Hub, authenticate or use a mirror.
+- **Docs**: <https://kubernetes.io/docs/concepts/containers/images/#imagepullbackoff>, <https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/>.
+- **Scope**: `generic` (with provider-specific variants in §8.x, §9.6, §10.2).
+
+### 1.2 InvalidImageName
+
+- **Manifestation**: `state.waiting.reason=InvalidImageName`. Event `reason=InspectFailed` or `Failed`, message `couldn't parse image reference`.
+- **Root cause**: malformed `spec.containers[].image` — stray whitespace, unexpanded `${TAG}`, uppercase in registry host.
+- **Detection**: `state.waiting.reason == "InvalidImageName"`.
+- **Report**: offending image string, container name.
+- **Remediation**: fix the image reference.
+- **Scope**: `generic`.
+
+### 1.3 ErrImageNeverPull / ImageInspectError
+
+- **Manifestation**: `state.waiting.reason ∈ {"ErrImageNeverPull","ImageInspectError"}`. `ErrImageNeverPull` appears when `imagePullPolicy=Never` and the image isn't preloaded on the node.
+- **Root cause**: bad `imagePullPolicy`; node-local image corruption.
+- **Detection**: direct reason match.
+- **Remediation**: set `imagePullPolicy: IfNotPresent`, or preload the image. GKE Autopilot denies `Never`.
+- **Scope**: `generic`.
+
+### 1.4 Image architecture mismatch (amd64 / arm64)
+
+- **Manifestation**: `ErrImagePull` (manifest lacks the node's arch) **or** container starts then immediately exits — `terminated.reason=Error`, `exitCode ∈ {1, 139, 255}`, logs contain `exec format error`.
+- **Root cause**: image built for one arch, scheduled onto a different-arch node (EKS Graviton, GKE T2A, AKS Ampere).
+- **Detection**: cross-reference `pod.spec.nodeName` → `node.status.nodeInfo.architecture` vs image manifest arch. The quick heuristic is `exec format error` in logs.
+- **Remediation**: publish a multi-arch manifest (`docker buildx --platform linux/amd64,linux/arm64`) or pin `nodeSelector: kubernetes.io/arch: amd64`.
+- **Docs**: <https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-arch>.
+- **Scope**: `generic` (prevalence: `eks` Graviton, `gke` T2A, `aks` Ampere).
+
+### 1.5 Image pull secret not propagated to ServiceAccount
+
+- **Manifestation**: same as §1.1 (auth branch). Works under `default` SA, fails after switching to a custom SA that lacks `imagePullSecrets`.
+- **Detection**: Pod's SA `imagePullSecrets` is empty while image is private.
+- **Report**: point at the ServiceAccount, not the pod.
+- **Scope**: `generic`.
+
+---
+
+## 2. Runtime / Container Lifecycle
+
+### 2.1 CrashLoopBackOff
+
+- **Manifestation**: `state.waiting.reason=CrashLoopBackOff`; `lastState.terminated.exitCode != 0`; event `reason=BackOff`, message `Back-off restarting failed container`.
+- **Root cause**: bad entrypoint/args, missing config, unhandled panic on startup, dependency unreachable, port conflict.
+- **Detection**: `state.waiting.reason=="CrashLoopBackOff"`. Subclassify via `lastState.terminated.{reason,exitCode}` and previous-container logs. Exit codes: `137`=SIGKILL (often OOM precursor), `139`=SIGSEGV, `143`=SIGTERM.
+- **Report**: container name, `exitCode`, last N lines of `kubectl logs --previous`, restart count.
+- **Remediation**: fetch previous-container logs; fix the startup path.
+- **Docs**: <https://kubernetes.io/docs/tasks/debug/debug-application/debug-pods/>.
+- **Scope**: `generic`.
+
+### 2.2 OOMKilled
+
+- **Manifestation**: `lastState.terminated.reason=OOMKilled`, `exitCode=137`. Often followed by `CrashLoopBackOff`. Container-scoped; not node-level pressure.
+- **Root cause**: exceeded `resources.limits.memory`; memory leak; runtime heap not sized to the limit (JVM / .NET / Node).
+- **Detection**: `containerStatuses[].lastState.terminated.reason == "OOMKilled"`.
+- **Report**: container, current memory limit, recommend inspecting metrics.
+- **Remediation**: raise `limits.memory`; fix the leak; size the runtime heap (`-XX:MaxRAMPercentage`, `GOMEMLIMIT`).
+- **Docs**: <https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/>.
+- **Scope**: `generic`.
+
+### 2.3 Liveness / Readiness / Startup probe failures
+
+- **Manifestation**:
+  - **Liveness** fail → event `reason=Unhealthy` + `reason=Killing`, message `Liveness probe failed: ...`; container restarts, usually → CrashLoopBackOff.
+  - **Readiness** fail → `pod.conditions[type=Ready,status=False]`; Endpoints excludes the pod; Deployment `Available` stays false.
+  - **Startup** fail → container killed after `failureThreshold * periodSeconds`; same `Unhealthy` event with probe-type=Startup.
+- **Detection**:
+  - Event `reason=Unhealthy` with message prefix `(Liveness|Readiness|Startup) probe failed`.
+  - `containerStatuses[].ready=false` with `restartCount > 0`.
+- **Report**: probe type, endpoint (`httpGet.path` / `port`, `exec.command`, `tcpSocket.port`), failure count, last error.
+- **Remediation**: add a `startupProbe`; widen `initialDelaySeconds` / `failureThreshold`; verify the endpoint.
+- **Docs**: <https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/>.
+- **Scope**: `generic`.
+
+### 2.4 CreateContainerConfigError
+
+- **Manifestation**: `state.waiting.reason=CreateContainerConfigError`. Event `reason=Failed`, message `couldn't find key X in ConfigMap Y` or `secret "X" not found`.
+- **Root cause**: Pod references a missing ConfigMap/Secret or missing key; invalid `subPath`; broken `envFrom`.
+- **Detection**: reason match; parse event message for `configmap|secret|key`.
+- **Report**: name the missing object/key.
+- **Remediation**: create the object/key, or mark `optional: true`.
+- **Scope**: `generic`.
+
+### 2.5 CreateContainerError
+
+- **Manifestation**: `state.waiting.reason=CreateContainerError`. Runtime-specific event message: `container name "x" already in use`, `invalid mount`, `path not allowed`, `failed to create shim task`.
+- **Root cause**: runtime-level rejection — hostPath denied, seccomp profile absent, invalid capability, name collision after crash, bad volume mount.
+- **Detection**: reason match; branch on message.
+- **Scope**: `generic`.
+
+### 2.6 RunContainerError
+
+- **Manifestation**: `state.waiting.reason=RunContainerError`. Messages like `exec: "/app": permission denied`, `no such file or directory`.
+- **Root cause**: entrypoint not executable; missing binary; arch mismatch (overlap with §1.4).
+- **Scope**: `generic`.
+
+### 2.7 ContainerStatusUnknown / ContainerCannotRun
+
+- **Manifestation**: `state.terminated.reason=ContainerStatusUnknown` (kubelet lost track after a restart); `state.waiting.reason=ContainerCannotRun`.
+- **Scope**: `generic`.
+
+### 2.8 Ephemeral storage eviction
+
+- **Manifestation**: Pod phase `Failed`, `status.reason=Evicted`, `status.message` contains `The node was low on resource: ephemeral-storage`. Event `reason=Evicted`.
+- **Root cause**: wrote past `limits.ephemeral-storage`; `emptyDir` bloat; log bloat without rotation; node DiskPressure.
+- **Detection**: `pod.status.reason == "Evicted"` + message regex on `ephemeral-storage`.
+- **Remediation**: set `limits.ephemeral-storage`; use `emptyDir.sizeLimit`; mount a PVC for large writes.
+- **Docs**: <https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/>.
+- **Scope**: `generic`.
+
+### 2.9 Job DeadlineExceeded
+
+- **Manifestation**: `job.status.conditions[type=Failed,reason=DeadlineExceeded]`; pod `status.reason=DeadlineExceeded`; event `reason=DeadlineExceeded`.
+- **Root cause**: `activeDeadlineSeconds` shorter than job runtime.
+- **Docs**: <https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-termination-and-cleanup>.
+- **Scope**: `generic`.
+
+### 2.10 Job BackoffLimitExceeded
+
+- **Manifestation**: `job.status.conditions[type=Failed,reason=BackoffLimitExceeded]`; `status.failed >= spec.backoffLimit + 1`.
+- **Detection**: condition match; last pod's `terminated.exitCode` carries the real cause.
+- **Scope**: `generic`.
+
+### 2.11 Job FailedIndexes / PodFailurePolicy (K8s ≥1.28)
+
+- **Manifestation**: Indexed Jobs — `status.failedIndexes`, `conditions[reason in {FailedIndexes,PodFailurePolicy}]`.
+- **Scope**: `generic`.
+
+---
+
+## 3. Scheduling
+
+### 3.1 FailedScheduling — insufficient resources
+
+- **Manifestation**: Pod `Pending`; `conditions[type=PodScheduled,status=False,reason=Unschedulable]`. Event `reason=FailedScheduling`, message `0/N nodes are available: N Insufficient (cpu|memory|ephemeral-storage|pods)`.
+- **Detection**: event message regex on `Insufficient (cpu|memory|ephemeral-storage|pods)`.
+- **Remediation**: reduce `requests`; add nodes; enable cluster autoscaler.
+- **Docs**: <https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/>.
+- **Scope**: `generic`.
+
+### 3.2 FailedScheduling — taints not tolerated
+
+- **Detection**: `FailedScheduling` message contains `had untolerated taint {key=value:NoSchedule}` or `node(s) had taint`.
+- **Notable taints to recognize and surface**:
+  - `node.kubernetes.io/not-ready`, `unreachable` — node degraded.
+  - `node.kubernetes.io/unschedulable` — cordoned.
+  - **GKE**: `nvidia.com/gpu=present:NoSchedule`, `cloud.google.com/gke-spot=true:NoSchedule`, `components.gke.io/gke-managed-components=true:NoSchedule`.
+  - **EKS**: `eks.amazonaws.com/compute-type=fargate:NoSchedule`, `karpenter.sh/disrupted`.
+  - **AKS**: `kubernetes.azure.com/scalesetpriority=spot:NoSchedule`, `CriticalAddonsOnly=true:NoSchedule` (system pool).
+- **Remediation**: add matching `tolerations`, or target a different node pool.
+- **Scope**: `generic` + provider taints (`gke`, `eks`, `aks`).
+
+### 3.3 FailedScheduling — nodeAffinity / nodeSelector / pod (anti-)affinity / topologySpread
+
+- **Detection**: message contains `didn't match Pod's node affinity/selector`, `didn't match pod affinity`, `didn't match pod anti-affinity`, or `didn't match pod topology spread constraints`.
+- **Root cause**: node labels missing; required anti-affinity impossible for cluster topology; `maxSkew` too tight.
+- **Remediation**: align labels (`topology.kubernetes.io/zone`, `kubernetes.io/arch`, `node.kubernetes.io/instance-type`, `cloud.google.com/gke-nodepool`, `eks.amazonaws.com/nodegroup`, `agentpool`); relax to `preferredDuringScheduling`.
+- **Scope**: `generic`.
+
+### 3.4 FailedScheduling — autoscaler won't scale up
+
+- **Manifestation**: `0/0 nodes are available`, or autoscaler event `NotTriggerScaleUp` on the pod with reasons like `pod didn't trigger scale-up: N node(s) didn't match ...`.
+- **Detection**:
+  - **GKE CA**: events on pod from source `cluster-autoscaler` with `NotTriggerScaleUp`.
+  - **EKS Karpenter**: pod events from source `karpenter`; `NodeClaim.status.conditions[type=Launched,status=False,reason=InsufficientCapacityError]`.
+  - **AKS CA**: same `NotTriggerScaleUp` event.
+- **Scope**: `generic` heuristic with provider-specific event sources.
+
+### 3.5 PodDisruptionBudget blocking rollout
+
+- **Manifestation**: Eviction API returns 429 during rollout/drain; Deployment hangs at N-1 of N.
+- **Detection**: `PodDisruptionBudget.status.disruptionsAllowed == 0` while `expectedPods > currentHealthy`. 429s on `Eviction` via controller logs or audit.
+- **Remediation**: raise `maxUnavailable` (or lower `minAvailable`) on the PDB; scale replicas up first; wait for healthy pods.
+- **Docs**: <https://kubernetes.io/docs/tasks/run-application/configure-pdb/>.
+- **Scope**: `generic`.
+
+### 3.6 Scheduling gates (K8s ≥1.27)
+
+- **Manifestation**: `spec.schedulingGates[].name` present; `conditions[type=PodScheduled,status=False,reason=SchedulingGated]`.
+- **Root cause**: external controller hasn't cleared the gate (Karpenter consolidation, Kueue).
+- **Scope**: `generic`.
+
+### 3.7 FailedScheduling — too many pods / max-pods cap
+
+- **Detection**: message `too many pods` or `Insufficient pods`. Kubelet `--max-pods` (default 110, provider-overridden; EKS default tied to ENI capacity per instance type).
+- **Scope**: `generic`; provider defaults differ (see §9.4).
+
+### 3.8 hostPort collisions
+
+- **Detection**: `FailedScheduling` message `node(s) didn't have free ports for the requested pod ports`.
+- **Scope**: `generic`.
+
+### 3.9 Extended resources not advertised
+
+- **Detection**: `FailedScheduling ... Insufficient nvidia.com/gpu` (or equivalent).
+- **Remediation**: install the device plugin / add a node pool that advertises the resource.
+- **Scope**: `generic`.
+
+---
+
+## 4. Storage
+
+### 4.1 PVC Pending — no StorageClass / provisioning failure
+
+- **Manifestation**: `pvc.status.phase=Pending`. Events: `reason ∈ {ProvisioningFailed,FailedBinding,ExternalProvisioning}`, messages like `no persistent volumes available for this claim and no storage class is set`, `failed to provision volume with StorageClass "X"`.
+- **Root cause**: missing/misnamed `storageClassName`; cloud-disk quota; zone mismatch with `volumeBindingMode=Immediate`.
+- **Detection**: `pvc.status.phase=="Pending"` past ~30s + event reason match.
+- **Remediation**: set correct StorageClass; prefer `volumeBindingMode: WaitForFirstConsumer` for zonal volumes.
+- **Docs**: <https://kubernetes.io/docs/concepts/storage/persistent-volumes/>.
+- **Scope**: `generic`.
+
+### 4.2 FailedMount / FailedAttachVolume
+
+- **Manifestation**: Pod stuck `ContainerCreating`. Event `reason ∈ {FailedMount,FailedAttachVolume}`. Common messages:
+  - `Unable to attach or mount volumes: ... timed out waiting for the condition` — slow/stuck CSI.
+  - `Multi-Attach error for volume` — RWO volume still attached to a previous node.
+  - `does not exist` — PV/disk deleted out of band.
+  - `rpc error: code = ... CSI` — CSI driver-specific.
+- **Root cause**: CSI crash; multi-attach after pod rescheduling; bad fsType; cloud IAM missing; backend network; filesystem repair needed.
+- **Detection**: event reason match; branch on message.
+- **Scope**: `generic` (with provider variants §4.3).
+
+### 4.3 FailedAttachVolume — cloud credentials / quotas
+
+Provider discriminators on the event message:
+
+- **EKS**: `UnauthorizedOperation`, `VolumeLimitExceeded` (EBS caps 39–128 per instance by type), `IncorrectState`.
+- **GKE**: `googleapi: Error 403: ... requires one of ["compute.instances.attachDisk"]`, `QUOTA_EXCEEDED`.
+- **AKS**: `Code="OperationNotAllowed"`, `Code="DiskAttachmentFailed"`, `AttachVolume.Attach failed ... cannot attach data disk ... lun`.
+
+### 4.4 CSI driver not installed
+
+- **Manifestation**: PVC stuck; events `waiting for a volume to be created, either by external provisioner "ebs.csi.aws.com" or manually created by system administrator`.
+- **Detection**: `StorageClass.provisioner` has no matching running CSI controller / no `CSIDriver` object / no `CSINode` advertising it.
+- **Scope**: `eks` (EBS CSI is an addon since 1.23), `gke` (PD CSI), `aks` (Azure Disk/File CSI, default).
+
+### 4.5 StatefulSet ordinal stuck / PVC pending
+
+- **Manifestation**: `sts.status.readyReplicas < spec.replicas`; pod `web-2` stuck `Pending` because PVC `data-web-2` won't bind (zone pin, quota).
+- **Detection**: PVC owned by StatefulSet, phase `Pending`; StatefulSet `currentReplicas` stalled.
+- **Remediation**: align zone topology; raise disk quota; use `WaitForFirstConsumer`.
+- **Scope**: `generic`.
+
+### 4.6 Read-only filesystem / permission denied
+
+- **Manifestation**: container crashes writing to mount; logs `read-only file system` or `permission denied`.
+- **Root cause**: `readOnlyRootFilesystem: true` without a writable volume; fsGroup mismatch; CSI doesn't support fsGroup.
+- **Detection**: combine `securityContext.readOnlyRootFilesystem` with crash logs. Hard to detect generically — surface via probe failures + log keyword.
+- **Scope**: `generic`.
+
+### 4.7 VolumeSnapshot / online-resize failures
+
+- **Manifestation**: PVC condition `FileSystemResizePending`; event `VolumeResizeFailed`.
+- **Scope**: `generic`.
+
+---
+
+## 5. Network
+
+### 5.1 FailedCreatePodSandBox — CNI / IPAM
+
+- **Manifestation**: Pod stuck `ContainerCreating`. Event `reason=FailedCreatePodSandBox`. Message branches:
+  - `no IP addresses available in range set` / `InsufficientFreeAddressesInSubnet` — subnet IP exhaustion.
+  - `failed to assign an IP address to container` — IPAM error.
+  - `context deadline exceeded` — CNI daemon unhealthy.
+- **Detection**: reason match; branch on message.
+- **Provider discriminators**:
+  - **EKS VPC CNI**: `InsufficientFreeAddressesInSubnet`, `unable to attach ENI`, `AttachmentLimitExceeded`. Mitigations: prefix delegation, `WARM_ENI_TARGET`, larger subnets, custom networking.
+  - **GKE**: `IP_SPACE_EXHAUSTED` on Pod CIDR / secondary range. Add secondary ranges or enable "Discover additional Pod IP address ranges".
+  - **AKS Azure CNI (classic)**: `SubnetIsFull`, `Failed to allocate address`. Migrate to Azure CNI Overlay or shrink per-node CIDR.
+  - **AKS kubenet**: route-table cap (400 routes).
+- **Docs**:
+  - EKS: <https://docs.aws.amazon.com/eks/latest/userguide/pod-networking.html>.
+  - GKE: <https://cloud.google.com/kubernetes-engine/docs/how-to/alias-ips>.
+  - AKS: <https://learn.microsoft.com/azure/aks/configure-azure-cni>.
+- **Scope**: `generic` event, provider-specific diagnostics.
+
+### 5.2 NetworkPolicy blocking traffic
+
+- **Manifestation**: no direct event — symptom is readiness probe failure (if probe uses pod-to-pod) or app-level connection errors. Kubelet probes originate on the node and still succeed.
+- **Detection**: correlate readiness failures with a NetworkPolicy selecting the pod that lacks a matching ingress/egress allow rule. Requires introspection, not an event match.
+- **Remediation**: add an explicit allow rule; test with `kubectl run -it --rm netshoot`.
+- **Docs**: <https://kubernetes.io/docs/concepts/services-networking/network-policies/>.
+- **Scope**: `generic`.
+
+### 5.3 Service type=LoadBalancer provisioning failure
+
+- **Manifestation**: `svc.status.loadBalancer.ingress` never populated. Events on Service: `reason ∈ {SyncLoadBalancerFailed, EnsuringLoadBalancer, CreatingLoadBalancerFailed}`.
+- **Detection**: `spec.type=="LoadBalancer"` AND `len(status.loadBalancer.ingress)==0` past the provisioning SLO, plus Service events.
+- **Provider discriminators on message**:
+  - **EKS** (in-tree / AWS LB Controller): `TooManyLoadBalancers`, `AccessDenied` (missing IAM), `no matching subnets` (missing `kubernetes.io/role/elb` or `kubernetes.io/role/internal-elb` subnet tags), `SecurityGroupLimitExceeded`.
+  - **GKE**: `googleapi: Error 403 ... forwardingRules.create`, `QUOTA_EXCEEDED`, `BackendService not ready`. NEG sync errors from `neg-controller`.
+  - **AKS**: `OutboundRuleCannotBeUsedWithLoadBalancerSku`, `PublicIPCountLimitReached`, `LoadBalancerInUseByVirtualMachineScaleSet`, `AuthorizationFailed` (missing role on `MC_` resource group).
+- **Docs**:
+  - EKS: <https://kubernetes-sigs.github.io/aws-load-balancer-controller/>.
+  - GKE: <https://cloud.google.com/kubernetes-engine/docs/how-to/load-balance-ingress>.
+  - AKS: <https://learn.microsoft.com/azure/aks/load-balancer-standard>.
+- **Scope**: provider-specific (`eks`, `gke`, `aks`).
+
+### 5.4 Ingress controller / IngressClass misconfig
+
+- **Manifestation**: Ingress created but no address, or path routes 404. Events from the controller (or none, if no controller is installed).
+- **Detection**:
+  - `ingress.spec.ingressClassName` points to a nonexistent `IngressClass` → no controller.
+  - **GKE ingress-gce**: events `Sync`, `LoadBalancerSync`, `BackendConfig not found`, `neg not ready for target`.
+  - **AWS ALB Controller**: mismatch between legacy `kubernetes.io/ingress.class` annotation and `ingressClassName`; `FailedBuildModel`.
+  - **AKS AGIC / nginx**: controller pod logs.
+- **Scope**: provider-specific variants.
+
+### 5.5 TLS cert / Secret mismatch in Ingress
+
+- **Manifestation**: `ingress.spec.tls[].secretName` references a missing or malformed Secret (not `kubernetes.io/tls` type; cert CN/SAN mismatch).
+- **Detection**: missing Secret → controller emits `FailedGet`; cert-manager `Certificate.Ready=False, reason∈{Issuing,Failed}`; browser serves default cert.
+- **Remediation**: provision via cert-manager or upload valid `tls.crt`/`tls.key`; ensure SAN covers the host.
+- **Scope**: `generic` (with GKE Managed Certs and AKS App Gateway variants).
+
+### 5.6 CoreDNS / service discovery failure
+
+- **Manifestation**: apps can't resolve hostnames; HTTP-name probes fail.
+- **Detection**: readiness failures + CoreDNS pods `Ready=False` or elevated error rate.
+- **Scope**: `generic`.
+
+### 5.7 externalTrafficPolicy=Local with no local endpoint
+
+- **Manifestation**: Service type=LoadBalancer/NodePort with `externalTrafficPolicy=Local` — cloud LB health checks fail on nodes without a ready pod; LB marks targets unhealthy; app reports 5xx despite being "deployed".
+- **Detection**: `spec.externalTrafficPolicy=="Local"` + pod is absent from a node that the LB health-checks.
+- **Scope**: `generic`.
+
+### 5.8 Dual-stack / ipFamilyPolicy mismatch
+
+- **Manifestation**: Service create rejected when `ipFamilyPolicy` or `ipFamilies` don't match cluster configuration.
+- **Scope**: `generic`.
+
+---
+
+## 6. Admission / Validation
+
+### 6.1 Invalid manifest (apply-time)
+
+- **Manifestation**: `kubectl apply` (or controller create) returns HTTP 4xx. No pod is created.
+- **Examples**: schema violation; immutable-field change (Deployment `selector`, Service `clusterIP`, StatefulSet `volumeClaimTemplates`); `PVC.spec.resources.requests.storage` shrink.
+- **Detection**: apply-time error, not a runtime event. For Nullstone, this surfaces as an apply error before any watcher starts.
+- **Scope**: `generic`.
+
+### 6.2 Admission webhook rejection (validating / mutating)
+
+- **Manifestation**: create returns `admission webhook "x.example.com" denied the request: <reason>`. For Deployments this manifests as `Deployment.conditions[type=ReplicaFailure,status=True,reason=FailedCreate]` with the webhook message; event on the ReplicaSet `reason=FailedCreate`.
+- **Detection**:
+  - Deployment condition: `status=True, type=ReplicaFailure` with message containing `admission webhook ... denied`.
+  - RS events: `reason=FailedCreate` with webhook name in message.
+- **Common offenders**: OPA/Gatekeeper, Kyverno, cert-manager, service meshes (Istio/Linkerd injectors), provider policy controllers (GKE Policy Controller, Azure Policy).
+- **Remediation**: check the webhook's policies/logs; if the webhook is down, inspect `failurePolicy`.
+- **Docs**: <https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/>.
+- **Scope**: `generic`.
+
+### 6.3 Pod Security Admission (PSA) denial
+
+- **Manifestation**: create rejected `pods "x" is forbidden: violates PodSecurity "restricted:v1.N": <control list>`. Deployment surfaces it as `ReplicaFailure`.
+- **Detection**: condition/event message contains `violates PodSecurity`.
+- **Root cause**: namespace labeled `pod-security.kubernetes.io/enforce=restricted|baseline` and pod spec violates (privileged, hostPath, `runAsNonRoot=false`, caps).
+- **Remediation**: drop caps; `runAsNonRoot: true`; `seccompProfile: RuntimeDefault`; remove hostPath; or relax the namespace label.
+- **Docs**: <https://kubernetes.io/docs/concepts/security/pod-security-admission/>.
+- **Scope**: `generic` (GKE Autopilot enforces `restricted`+; EKS/AKS opt-in).
+
+### 6.4 RBAC / ServiceAccount denial (in-cluster API calls)
+
+- **Manifestation**: pod runs; controller/operator logs `forbidden: User "system:serviceaccount:ns:sa" cannot ... at the cluster scope`. In-cluster API calls receive 403. No standard pod event.
+- **Detection**: app/operator status; audit log 403 trail.
+- **Remediation**: create appropriate `Role`/`ClusterRole` + `RoleBinding`/`ClusterRoleBinding`.
+- **Scope**: `generic`.
+
+### 6.5 ResourceQuota denial
+
+- **Manifestation**: Pod creation blocked → `Deployment.conditions[type=ReplicaFailure,reason=FailedCreate]` with message `exceeded quota: compute-resources, requested: ..., used: ..., limited: ...`. Event on the RS.
+- **Detection**: condition/event match + message prefix `pods "x" is forbidden: exceeded quota`.
+- **Remediation**: raise the ResourceQuota; reduce requests; set defaults via LimitRange.
+- **Docs**: <https://kubernetes.io/docs/concepts/policy/resource-quotas/>.
+- **Scope**: `generic`.
+
+### 6.6 LimitRange denial or silent defaulting
+
+- **Manifestation**: apply rejected with `maximum cpu usage per Container is X, but limit is Y`; or requests/limits silently defaulted → unexpected OOM.
+- **Detection**: admission error text contains `LimitRange` or `minimum|maximum ... per Container`.
+- **Scope**: `generic`.
+
+### 6.7 SecurityContext denial beyond PSA (OPA, Kyverno, Autopilot)
+
+See §6.2 plus §8.1 for GKE Autopilot.
+
+### 6.8 Namespace Terminating / missing
+
+- **Manifestation**: create fails with `unable to create new content in namespace X because it is being terminated`.
+- **Detection**: error text match; `namespace.status.phase=="Terminating"` with stuck finalizers.
+- **Scope**: `generic`.
+
+### 6.9 Large Secret / ConfigMap
+
+- **Manifestation**: etcd write limit (~1 MiB) rejects apply.
+- **Scope**: `generic`.
+
+---
+
+## 7. Rollout / Controller
+
+### 7.1 Deployment ProgressDeadlineExceeded
+
+- **Manifestation**: `deployment.status.conditions[type=Progressing,status=False,reason=ProgressDeadlineExceeded]`; message `Deployment "x" exceeded its progress deadline`. Fires after `spec.progressDeadlineSeconds` (default 600s) without forward progress.
+- **Detection**: condition match is the authoritative top-level signal. Drill down into the newest RS's pods for the underlying reason.
+- **Docs**: <https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#failed-deployment>.
+- **Scope**: `generic`. Nullstone already detects this in `check_deployment.go` — enrichment should come from §1–§6.
+
+### 7.2 Deployment ReplicaFailure
+
+- **Manifestation**: `deployment.status.conditions[type=ReplicaFailure,status=True]` with `reason=FailedCreate` (or similar). Points to a ReplicaSet blocked from creating pods.
+- **Common causes**: quota (§6.5), admission webhook (§6.2), PSA (§6.3), missing SA / bad imagePullSecrets, invalid toleration.
+- **Detection**: condition present; mirror to newest RS's events.
+- **Scope**: `generic`. **Gap in current Nullstone** — not surfaced today.
+
+### 7.3 Rollout stuck on maxSurge / maxUnavailable math
+
+- **Manifestation**: `updatedReplicas < spec.replicas`; `availableReplicas` stuck at exactly `replicas - maxUnavailable`; new pods never reach Ready.
+- **Root cause**: new pods fail probes AND `maxUnavailable=0`; or `maxSurge=0` with no cluster capacity for one more.
+- **Detection**: newest-RS `availableReplicas` stuck; old-RS `replicas` at `spec.replicas - maxUnavailable`; newest-RS pods show probe failures.
+- **Remediation**: fix the probe; temporarily raise `maxSurge` when cluster capacity is the bottleneck.
+- **Scope**: `generic`.
+
+### 7.4 minReadySeconds hold
+
+- **Manifestation**: pod `Ready=True` but not counted as available for `minReadySeconds`. Briefly looks frozen.
+- **Detection**: `pod.conditions[type=Ready].lastTransitionTime` within the window.
+- **Scope**: `generic`.
+
+### 7.5 Rollout blocked by PDB
+
+See §3.5. Deployment `Progressing` can still be `True` while new pods can't evict old ones. Visible via `Eviction` 429s.
+
+### 7.6 HPA churn during rollout
+
+- **Manifestation**: HPA writes `spec.replicas` mid-rollout; evicted pods flash `Preempted` / `FailedScaleIn`.
+- **Detection**: HPA `status.currentReplicas` oscillating; writes to `Deployment.spec.replicas` during the rollout window.
+- **Remediation**: tune `behavior.scaleDown.stabilizationWindowSeconds`; pause HPA during deploys.
+- **Scope**: `generic`.
+
+### 7.7 VPA eviction mid-rollout
+
+- **Manifestation**: pods evicted (VPA admission rewrites requests); events `reason=EvictedByVPA` (or similar).
+- **Scope**: `generic` (GKE VPA is native; EKS/AKS require install).
+
+### 7.8 Readiness gate never satisfied
+
+- **Manifestation**: `pod.status.conditions[type=<gate>]` stays `False` or absent; `Ready=False` indefinitely even though container probes pass; Deployment never becomes Available.
+- **Common gates**:
+  - `target-health.elbv2.k8s.aws/<ingress>_<svc>_<port>` — AWS Load Balancer Controller.
+  - Service-mesh readiness gates.
+- **Detection**: `pod.spec.readinessGates[]` combined with `pod.status.conditions[type=<gate>].status != "True"`.
+- **Remediation**: diagnose the external system the gate represents — ALB target health: security group, health-check path, subnet.
+- **Docs**: <https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-readiness-gate>.
+- **Scope**: `generic` (most common on `eks`).
+
+### 7.9 Selector mismatch / orphaned ReplicaSets
+
+- **Manifestation**: apply error `Deployment.apps "x" is invalid: spec.selector: field is immutable`. Or two RSes with the same selector owned by different Deployments → thrash.
+- **Scope**: `generic`.
+
+### 7.10 Stuck Terminating pods (finalizers)
+
+- **Manifestation**: Pod stays `Terminating` with `deletionTimestamp` set; finalizers aren't removed (custom operator finalizer, `kubernetes.io/pv-protection`). Blocks rollout under strict PDBs or `strategy.type=Recreate`.
+- **Detection**: `metadata.deletionTimestamp` set AND `metadata.finalizers` non-empty past termination grace.
+- **Scope**: `generic`.
+
+### 7.11 Helm pre/post-hook Job failure
+
+- **Manifestation**: Helm rolls back on hook-Job `BackoffLimitExceeded`. Surface the Job pod's crash details.
+- **Scope**: `generic` (applies to Nullstone's Helm-based deploys).
+
+---
+
+## 8. Provider-specific — GKE
+
+### 8.1 GKE Autopilot — Warden policy violations
+
+- **Manifestation**: apply rejected with `GKE Warden rejected the request: ... autopilot.gke.io/<policy>`. Common policies:
+  - `no-host-namespace` (`hostNetwork` / `hostPID` / `hostIPC`)
+  - `no-host-port`
+  - `no-host-path` (only a narrow allowlist)
+  - `linux-capabilities` (most caps denied)
+  - `no-privileged`
+  - `workload-separation` (conflicting nodeSelector/tolerations)
+  - `no-defaultserviceaccount-token`
+  - `no-write-mode-hostpath`
+- **Detection**: admission-error message matches `autopilot.gke.io/` or `GKE Warden`.
+- **Docs**: <https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview>, <https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-security-constraints>.
+- **Scope**: `gke` (Autopilot).
+
+### 8.2 GKE Autopilot — resource constraints and rewriting
+
+- **Manifestation**: Requests auto-raised to Autopilot minimums (≈0.25 vCPU / 0.5 GiB per pod); CPU:memory ratio enforced (1 vCPU : 1–6.5 GiB). Admission message: `Autopilot set default resource requests ...` or rejection for ratio violation.
+- **Detection**: admission message contains `Autopilot`.
+- **Remediation**: set requests within the allowed ratio; use `cloud.google.com/compute-class` (Balanced/Scale-Out/Accelerator) for different envelopes.
+- **Docs**: <https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests>.
+- **Scope**: `gke` (Autopilot).
+
+### 8.3 GKE — managed namespace restrictions
+
+- **Manifestation**: writes to `kube-system`, `gke-*`, `gmp-system`, `gke-managed-*` rejected.
+- **Scope**: `gke` (Autopilot strictly; Standard protects a subset).
+
+### 8.4 GKE Workload Identity misconfig
+
+- **Manifestation**: Google SDK errors at runtime — `failed to find default credentials`, `could not refresh token: ... 403`. Pods run; cloud API calls fail.
+- **Detection** (pre-runtime, cross-object):
+  - ServiceAccount missing `iam.gke.io/gcp-service-account` annotation.
+  - Namespace not enabled for WI (on old clusters).
+  - Missing IAM binding `roles/iam.workloadIdentityUser` on the GSA for `serviceAccount:PROJECT.svc.id.goog[NS/KSA]`.
+- **Docs**: <https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity>.
+- **Scope**: `gke`.
+
+### 8.5 GKE Alias IP / secondary range exhaustion
+
+- **Manifestation**: `FailedCreatePodSandBox` with `IP_SPACE_EXHAUSTED`; node creation may fail.
+- **Remediation**: add secondary ranges; enable "Discover additional Pod IP address ranges"; shrink per-node CIDR.
+- **Docs**: <https://cloud.google.com/kubernetes-engine/docs/how-to/flexible-pod-cidr>.
+- **Scope**: `gke`.
+
+### 8.6 GKE Ingress (GCLB) / NEG sync errors
+
+- **Manifestation**: Ingress `status.loadBalancer` empty. Events from source `loadbalancer-controller` or `neg-controller`: `Translate`, `Sync`, `BackendConfig "x" not found`, `neg not ready for target`.
+- **Detection**: event source + keyword match (`BackendConfig`, `FrontendConfig`, `neg`).
+- **Scope**: `gke`.
+
+### 8.7 GKE node-pool taints / special hardware
+
+- Examples: `nvidia.com/gpu`, `cloud.google.com/gke-preemptible`, `cloud.google.com/gke-spot`, `cloud.google.com/gke-tpu`. Pods without matching tolerations → `FailedScheduling`.
+- **Scope**: `gke`.
+
+### 8.8 GKE private cluster — webhook / registry reachability
+
+- **Manifestation**: external admission webhooks time out (`failed calling webhook ... context deadline exceeded`); non-GCR image pulls fail (`i/o timeout`) without Cloud NAT.
+- **Scope**: `gke` (private clusters).
+
+---
+
+## 9. Provider-specific — EKS
+
+### 9.1 IRSA misconfig
+
+- **Manifestation**: pods run; AWS SDK calls return `WebIdentityErr: unable to assume role: AccessDenied`, `InvalidIdentityToken`, or SDK `NoCredentialProviders`.
+- **Detection** (pre-runtime heuristics):
+  - ServiceAccount missing `eks.amazonaws.com/role-arn` annotation.
+  - Pod env missing `AWS_ROLE_ARN` / `AWS_WEB_IDENTITY_TOKEN_FILE` (should be auto-injected by the Pod Identity webhook / EKS Pod Identity Agent).
+  - IAM role trust policy doesn't federate the cluster OIDC provider, or `sub` condition ≠ `system:serviceaccount:<ns>:<sa>`.
+  - Cluster OIDC provider not created in IAM.
+- **Docs**: <https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html>.
+- **Scope**: `eks`.
+
+### 9.2 EKS Pod Identity misconfig
+
+- **Manifestation**: same SDK-level auth failures as §9.1.
+- **Detection**: no `PodIdentityAssociation` for the namespace/SA; `eks-pod-identity-agent` DaemonSet not running.
+- **Docs**: <https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html>.
+- **Scope**: `eks`.
+
+### 9.3 aws-auth ConfigMap / Access Entries missing
+
+- **Manifestation**: `kubectl` returns `You must be logged in to the server (Unauthorized)`; or node never joins (`NotReady` absent from `kubectl get nodes` while EC2 is running).
+- **Detection**: For node join — missing `mapRoles` entry with groups `system:bootstrappers,system:nodes` for the node IAM role. For humans/CI — missing `mapRoles`/`mapUsers`. New clusters use Access Entries instead.
+- **Docs**: <https://docs.aws.amazon.com/eks/latest/userguide/grant-k8s-access.html>.
+- **Scope**: `eks`.
+
+### 9.4 VPC CNI IP exhaustion / ENI limits
+
+- **Manifestation**: `FailedCreatePodSandBox` with `InsufficientFreeAddressesInSubnet`; or `aws-node` logs `AssignPrivateIpAddresses: Unable to assign, too many addresses assigned`.
+- **Remediation**: larger subnets; enable prefix delegation (`ENABLE_PREFIX_DELEGATION=true`); custom networking; smaller node instance types; IPv6.
+- **Docs**: <https://docs.aws.amazon.com/eks/latest/userguide/cni-increase-ip-addresses.html>.
+- **Scope**: `eks`.
+
+### 9.5 EKS Fargate profile constraints
+
+- **Manifestation**: pods stuck `Pending` with event message `no Fargate profiles match pod` or `Pod not supported on Fargate: ...`.
+- **Unsupported on Fargate**: privileged pods, DaemonSets, `hostNetwork`/`hostPath`, EBS (only EFS CSI), Classic LB, GPU.
+- **Detection**: event message contains `Fargate`; pod label `eks.amazonaws.com/compute-type=fargate`.
+- **Docs**: <https://docs.aws.amazon.com/eks/latest/userguide/fargate.html>.
+- **Scope**: `eks` (Fargate).
+
+### 9.6 ECR image-pull authorization
+
+- **Manifestation**: `ImagePullBackOff` with `no basic auth credentials` or `401 Unauthorized` on `*.dkr.ecr.*.amazonaws.com`.
+- **Root cause**: node IAM role missing `AmazonEC2ContainerRegistryReadOnly`; cross-account ECR without a repository policy; wrong-region endpoint.
+- **Detection**: event message contains `dkr.ecr.` + auth keywords.
+- **Scope**: `eks`.
+
+### 9.7 Node bootstrap failures
+
+- **Manifestation**: EC2 running but node absent from API server; or node `NotReady` with kubelet log `Unauthorized`.
+- **Causes**: wrong cluster name in userdata; aws-auth missing; security groups not allowing control plane; IMDSv2 hop limit (EKS ≥1.27 nodes).
+- **Scope**: `eks`.
+
+### 9.8 Security Groups for Pods
+
+- **Manifestation**: pod has `vpc.amazonaws.com/pod-eni` but stays `ContainerCreating` with ENI errors. Requires Nitro instances; increases per-instance ENI consumption.
+- **Scope**: `eks`.
+
+### 9.9 Karpenter — NodeClaim launch failure
+
+- **Manifestation**: pod `Pending` with Karpenter events `FailedLaunch`, `Incompatible`, `InsufficientCapacity`. `NodeClaim.status.conditions[type=Launched,status=False,reason=InsufficientCapacityError]`, message `no instance types satisfied resources ...`.
+- **Detection**: watch `NodeClaim.status.conditions`; pod events from source `karpenter`.
+- **Docs**: <https://karpenter.sh/docs/troubleshooting/>.
+- **Scope**: `eks` (and self-managed).
+
+---
+
+## 10. Provider-specific — AKS
+
+### 10.1 Workload Identity / Pod Identity misconfig
+
+- **Manifestation**: Azure API calls fail with `AADSTS700016` (invalid client), `AADSTS70021` (no matching federated identity credential), `AADSTS7000215` (invalid secret), or `ManagedIdentityCredential authentication failed`.
+- **Detection** (pre-runtime):
+  - ServiceAccount missing `azure.workload.identity/client-id`.
+  - Pod missing label `azure.workload.identity/use: "true"`.
+  - No Federated Identity Credential on the UAMI / App Registration linking OIDC issuer + `subject system:serviceaccount:<ns>:<sa>`.
+  - AKS cluster OIDC issuer or Workload Identity feature not enabled.
+- Legacy AAD Pod Identity (deprecated): missing `AzureIdentity` / `AzureIdentityBinding`; pod not selected by binding.
+- **Docs**: <https://learn.microsoft.com/azure/aks/workload-identity-overview>.
+- **Scope**: `aks`.
+
+### 10.2 ACR pull authentication
+
+- **Manifestation**: `ImagePullBackOff` with `unauthorized: authentication required` on `*.azurecr.io`.
+- **Root cause**: kubelet managed identity lacks `AcrPull` on the ACR; `--attach-acr` not run; private ACR without private endpoint from the node subnet; expired `imagePullSecrets`.
+- **Detection**: event registry host `.azurecr.io` + auth keywords.
+- **Remediation**: `az aks update -n X -g Y --attach-acr <acr>`; grant `AcrPull` to the kubelet identity.
+- **Docs**: <https://learn.microsoft.com/azure/aks/cluster-container-registry-integration>.
+- **Scope**: `aks`.
+
+### 10.3 Azure CNI IP exhaustion / kubenet route cap
+
+- **Manifestation**: `FailedCreatePodSandBox` with `SubnetIsFull`, `Failed to allocate address`, or `Failed to add route`.
+- **Root cause**:
+  - Azure CNI (classic): every pod consumes a VNet IP; subnet too small.
+  - Azure CNI Overlay: pod IPs are internal to the node; watch node-IP consumption.
+  - kubenet: route table cap (400 routes, one per node).
+- **Remediation**: migrate to Azure CNI Overlay (or Cilium data plane); expand subnet.
+- **Docs**: <https://learn.microsoft.com/azure/aks/concepts-network-cni-overview>.
+- **Scope**: `aks`.
+
+### 10.4 Azure Policy / Gatekeeper denial
+
+- **Manifestation**: admission webhook denial with policy names like `K8sAzureV2...`, `K8sPSP...`.
+- **Detection**: webhook name `gatekeeper-validating-webhook-configuration` with message referencing an `azure-policy` constraint template.
+- **Docs**: <https://learn.microsoft.com/azure/governance/policy/concepts/policy-for-kubernetes>.
+- **Scope**: `aks`.
+
+### 10.5 Azure Disk attach conflicts
+
+- **Manifestation**: `FailedAttachVolume` with messages like `disk(/subscriptions/.../disks/X) already attached to node(Y)`, `AttachDiskWhileBeingDetached`, `Cannot attach data disk 'X' to VM ... because the disk is already owned by VM 'Y'`.
+- **Root cause**: StatefulSet pod rescheduled; VMSS scale-in; out-of-band attach.
+- **Detection**: event message substring `already attached` / `owned by VM`.
+- **Remediation**: wait for detach, or force-detach via CSI annotation `disk.csi.azure.com/request-detach`.
+- **Scope**: `aks`.
+
+### 10.6 LoadBalancer provisioning (Standard SKU)
+
+- **Manifestation**: Service LB stuck with events including `OutboundRuleCannotBeUsedWithLoadBalancerSku`, `PublicIPCountLimitReached`, `LoadBalancerInUseByVirtualMachineScaleSet`, `AuthorizationFailed` (missing role on `MC_` resource group), `SubnetHasNoFreeAddresses` (internal LB).
+- **Remediation**: grant `Network Contributor` on the node resource group; request a quota increase.
+- **Scope**: `aks`.
+
+### 10.7 System node pool `CriticalAddonsOnly` taint
+
+- **Manifestation**: user workloads `FailedScheduling` with `had untolerated taint {CriticalAddonsOnly: true}`.
+- **Remediation**: add a user node pool (recommended) or tolerate the taint (not recommended).
+- **Scope**: `aks`.
+
+### 10.8 API server VNet integration / private cluster
+
+- **Manifestation**: admission webhooks time out; image pulls from external registries fail without outbound route.
+- **Scope**: `aks` (private clusters).
+
+---
+
+## 11. Node / Infrastructure
+
+### 11.1 Node NotReady
+
+- **Manifestation**: `node.conditions[type=Ready,status∈{False,Unknown}]`; auto-taints `node.kubernetes.io/not-ready` / `unreachable`; pods eventually evicted after `tolerationSeconds=300`.
+- **Root causes**: kubelet crash; container-runtime failure; network partition; `/var` disk full; `PLEG is not healthy`.
+- **Detection**: node condition + message (often mentions PLEG, `runtime network not ready`).
+- **Scope**: `generic`.
+
+### 11.2 Node pressure taints and evictions
+
+- Taints: `node.kubernetes.io/{memory,disk,pid}-pressure`, `network-unavailable`.
+- **Manifestation**: pod `status.reason=Evicted`; event `reason=Evicted`; message `The node was low on resource: (memory|ephemeral-storage|nodefs|imagefs|pids)`.
+- **Detection**: `pod.status.reason == "Evicted"` + message regex.
+- **Docs**: <https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/>.
+- **Scope**: `generic`.
+
+### 11.3 Spot / preemptible termination
+
+- **GKE**: node annotation / event `PreemptibleNodeDeletion`; taint `cloud.google.com/gke-spot`.
+- **EKS**: Spot interruption notice handled by `aws-node-termination-handler` → pod eviction `reason=TaintManagerEviction` or taint `node.kubernetes.io/unschedulable`.
+- **AKS**: scale-set spot eviction; `kubernetes.azure.com/scalesetpriority=spot`.
+- **Scope**: provider-specific.
+
+### 11.4 Taint-based eviction for unreachable nodes
+
+- **Manifestation**: pods `Terminating` then recreated elsewhere after `tolerationSeconds` (default 300s) of `NotReady|Unreachable` taint.
+- **Scope**: `generic`.
+
+### 11.5 Pod preemption by higher PriorityClass
+
+- **Manifestation**: event `reason=Preempted` with preemptor identified. `status.nominatedNodeName` set on the victim.
+- **Scope**: `generic`.
+
+### 11.6 DisruptionTarget condition (K8s ≥1.26)
+
+- **Manifestation**: `pod.status.conditions[type=DisruptionTarget,reason ∈ {PreemptionByScheduler, EvictionByEvictionAPI, DeletionByTaintManager, TerminationByKubelet}]` — structured disruption metadata useful for accurate reporting.
+- **Scope**: `generic`.
+
+### 11.7 RuntimeClass not found
+
+- **Manifestation**: `spec.runtimeClassName` references a missing `RuntimeClass`; pod fails to start with `CreateContainerError` message `no runtime for class ... is configured`.
+- **Scope**: `generic`.
+
+### 11.8 inotify / fd exhaustion on node
+
+- **Manifestation**: intermittent probe failures; node kernel logs `fs.inotify.max_user_instances`.
+- **Scope**: `generic`.
+
+---
+
+## 12. Reporting format (Phase 3 contract)
+
+Every cataloged failure should emit a structured log record with, at minimum, these fields. The wire format feeds Phase 3 log improvements and NUL-27 (Monitoring tab), NUL-29 (executions list), and NUL-30 (Deployment section).
+
+```yaml
+failure:
+  name: string         # canonical name from this catalog (e.g. "ImagePullBackOff", "PodSecurityDenial")
+  category: string     # top-level section: image|runtime|scheduling|storage|network|admission|rollout|provider|node
+  summary: string      # one-line root-cause summary
+  remediation: string  # one-line user-facing hint
+  object:
+    kind: string       # Pod | ReplicaSet | Deployment | PVC | Service | Ingress | Job | Node
+    namespace: string
+    name: string
+    container: string  # when applicable
+  signals:             # raw evidence for drill-down UIs
+    eventReason: string
+    eventMessage: string
+    waitingReason: string
+    terminatedReason: string
+    exitCode: int
+    condition: string  # e.g. "Progressing=False:ProgressDeadlineExceeded"
+  provider: string     # generic | gke | eks | aks
+  docs: [url]          # 1+ authoritative links
+```
+
+Consumers (Monitoring tab, executions list) filter on `category` + `provider`. The catalog's canonical names (`name`) are the stable contract — do not rename without a migration.
+
+---
+
+## 13. Open questions / follow-ups
+
+Items worth resolving before / during Phase 2:
+
+- **Probe failure labeling**: confirm whether the current event stream reliably carries the probe type in the message on all k8s versions we support. If not, parse from the `Killing` event that follows.
+- **Readiness-gate detection**: should we special-case `target-health.elbv2.k8s.aws/*` on EKS, or keep it generic?
+- **NetworkPolicy diagnosis**: detection requires introspection that may be too heavy for every deploy; consider making this opt-in or only firing when probes fail without another explanation.
+- **Admission-webhook failures**: when `failurePolicy=Fail` and the webhook itself is down, we want to distinguish "webhook rejected" from "webhook unreachable". Event messages differ: `denied the request` vs `failed calling webhook ... context deadline exceeded`.
+- **Provider signal plumbing**: the generic `k8s.Deployer` can surface most of this, but `aws/eks`, `gcp/gke`, `azure/aks` will need hooks for provider-specific cross-object checks (IRSA annotation, WI annotation, ACR attach status, subnet tagging).
+- **Evicted pods mid-rollout**: categorize under node (§11.2) vs. spot termination (§11.3) vs. PriorityClass preemption (§11.5) — they all carry `Evicted`/`Preempted` reasons but need different remediation hints.

--- a/k8s/failures/admission.go
+++ b/k8s/failures/admission.go
@@ -1,0 +1,93 @@
+package failures
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// classifyAdmissionEvent handles §6 (Admission / Validation) when the trigger
+// is an Event with reason=FailedCreate (typically on a ReplicaSet). The same
+// message also surfaces on the Deployment as ReplicaFailure (handled in rollout.go).
+func classifyAdmissionEvent(obj ObjectRef, ev corev1.Event) *Failure {
+	if ev.Reason != "FailedCreate" {
+		return nil
+	}
+	return classifyAdmissionMessage(obj, ev.Reason, ev.Message)
+}
+
+// classifyAdmissionMessage interprets an admission rejection message — used by
+// both the Event path and the Deployment ReplicaFailure path so the catalog
+// names match in either case.
+func classifyAdmissionMessage(obj ObjectRef, reason, msg string) *Failure {
+	lower := strings.ToLower(msg)
+	signals := Signals{EventReason: reason, EventMessage: msg}
+
+	switch {
+	case strings.Contains(lower, "violates podsecurity"):
+		return &Failure{
+			Name:        "PodSecurityDenial",
+			Category:    CategoryAdmission,
+			Summary:     "Namespace's PodSecurity policy rejected the pod",
+			Remediation: "Drop disallowed capabilities, set runAsNonRoot/seccompProfile, remove hostPath, or relax the namespace label.",
+			Object:      obj, Signals: signals, Provider: ProviderGeneric,
+			Docs: []string{"https://kubernetes.io/docs/concepts/security/pod-security-admission/"},
+		}
+	case strings.Contains(lower, "exceeded quota"):
+		return &Failure{
+			Name:        "ResourceQuotaExceeded",
+			Category:    CategoryAdmission,
+			Summary:     "Pod creation exceeded a ResourceQuota in the namespace",
+			Remediation: "Raise the quota, reduce requests, or set defaults via LimitRange.",
+			Object:      obj, Signals: signals, Provider: ProviderGeneric,
+			Docs: []string{"https://kubernetes.io/docs/concepts/policy/resource-quotas/"},
+		}
+	case strings.Contains(lower, "limitrange"), strings.Contains(lower, "minimum cpu"), strings.Contains(lower, "maximum cpu usage"), strings.Contains(lower, "maximum memory usage"):
+		return &Failure{
+			Name:        "LimitRangeDenied",
+			Category:    CategoryAdmission,
+			Summary:     "Pod requests/limits violate the namespace LimitRange",
+			Remediation: "Adjust requests/limits to fit the LimitRange bounds.",
+			Object:      obj, Signals: signals, Provider: ProviderGeneric,
+		}
+	case strings.Contains(lower, "admission webhook"):
+		return &Failure{
+			Name:        "AdmissionWebhookDenied",
+			Category:    CategoryAdmission,
+			Summary:     "An admission webhook denied the request",
+			Remediation: "Check the named webhook's policy/logs; if the webhook is unreachable, inspect failurePolicy.",
+			Object:      obj, Signals: signals, Provider: admissionWebhookProvider(lower),
+			Docs: []string{"https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/"},
+		}
+	case strings.Contains(lower, "autopilot.gke.io"), strings.Contains(lower, "gke warden"):
+		return &Failure{
+			Name:        "AutopilotPolicyDenied",
+			Category:    CategoryAdmission,
+			Summary:     "GKE Autopilot policy rejected the pod",
+			Remediation: "Remove the disallowed feature (hostPath, hostNetwork, privileged, restricted capability) or use a Standard cluster.",
+			Object:      obj, Signals: signals, Provider: ProviderGKE,
+			Docs: []string{"https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-security-constraints"},
+		}
+	case strings.Contains(lower, "is being terminated"):
+		return &Failure{
+			Name:        "NamespaceTerminating",
+			Category:    CategoryAdmission,
+			Summary:     "Namespace is being terminated; new objects cannot be created",
+			Remediation: "Wait for termination to complete, or investigate stuck finalizers on the namespace.",
+			Object:      obj, Signals: signals, Provider: ProviderGeneric,
+		}
+	}
+	return nil
+}
+
+// admissionWebhookProvider tags the webhook denial with a provider when the
+// message names a known managed webhook (Azure Policy, GKE Policy Controller).
+func admissionWebhookProvider(lowerMsg string) Provider {
+	switch {
+	case strings.Contains(lowerMsg, "azure-policy"), strings.Contains(lowerMsg, "k8sazure"):
+		return ProviderAKS
+	case strings.Contains(lowerMsg, "gatekeeper") && strings.Contains(lowerMsg, "azure"):
+		return ProviderAKS
+	}
+	return ProviderGeneric
+}

--- a/k8s/failures/classify.go
+++ b/k8s/failures/classify.go
@@ -1,0 +1,103 @@
+package failures
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ClassifyContainer inspects a single container's status against the catalog.
+// Returns nil when the container is healthy (no waiting failure, no terminated
+// failure). The dispatch order is:
+//
+//  1. Image-related waiting reasons (cheapest; no message regexes)
+//  2. Runtime / lifecycle (CrashLoopBackOff, OOMKilled, Create/RunContainerError, Terminated)
+//
+// The pod argument is used only to populate ObjectRef.Namespace/Name and to
+// allow future cross-checks; pass corev1.Pod{} if you only have a status.
+func ClassifyContainer(pod corev1.Pod, status corev1.ContainerStatus) *Failure {
+	obj := ObjectRef{
+		Kind:      "Pod",
+		Namespace: pod.Namespace,
+		Name:      pod.Name,
+		Container: status.Name,
+	}
+	if f := classifyImage(obj, status); f != nil {
+		return f
+	}
+	if f := classifyRuntime(obj, status); f != nil {
+		return f
+	}
+	return nil
+}
+
+// ClassifyPod returns failures derived from pod-level state — scheduling,
+// eviction, disruption. It does NOT recurse into containers; call
+// ClassifyContainer per container alongside this.
+func ClassifyPod(pod corev1.Pod) []Failure {
+	obj := ObjectRef{Kind: "Pod", Namespace: pod.Namespace, Name: pod.Name}
+	var out []Failure
+	if f := classifyPending(obj, pod); f != nil {
+		out = append(out, *f)
+	}
+	if f := classifyNode(obj, pod); f != nil {
+		out = append(out, *f)
+	}
+	return out
+}
+
+// ClassifyEvent maps a single corev1.Event to a Failure. Returns nil for events
+// whose reason isn't in the catalog (callers can still log the raw event).
+//
+// The dispatch is by reason because the event API namespaces failures that way;
+// message-based sub-classification happens inside the per-category function.
+func ClassifyEvent(ev corev1.Event) *Failure {
+	obj := ObjectRef{
+		Kind:      ev.InvolvedObject.Kind,
+		Namespace: ev.InvolvedObject.Namespace,
+		Name:      ev.InvolvedObject.Name,
+	}
+	switch ev.Reason {
+	case "FailedMount", "FailedAttachVolume", "ProvisioningFailed", "FailedBinding", "VolumeResizeFailed":
+		return setObserved(classifyVolumeEvent(obj, ev), ev)
+	case "FailedCreatePodSandBox", "SyncLoadBalancerFailed", "CreatingLoadBalancerFailed", "Unhealthy":
+		return setObserved(classifyNetworkEvent(obj, ev), ev)
+	case "FailedCreate":
+		return setObserved(classifyAdmissionEvent(obj, ev), ev)
+	case "FailedScheduling":
+		// Equivalent to PodScheduled=False:Unschedulable on the pod, but emitted
+		// as an event by the scheduler. Reuse the same message classifier.
+		return setObserved(classifySchedulingMessage(obj, ev.Message), ev)
+	case "Evicted":
+		// Pod-level eviction also fires an event; reuse the node classifier
+		// against a synthesized pod with status.reason=Evicted.
+		fake := corev1.Pod{Status: corev1.PodStatus{Reason: "Evicted", Message: ev.Message}}
+		return setObserved(classifyNode(obj, fake), ev)
+	}
+	return nil
+}
+
+// setObserved populates Failure.ObservedAt from the event's most recent timestamp.
+// Helper to avoid threading event context through every classifier.
+func setObserved(f *Failure, ev corev1.Event) *Failure {
+	if f == nil {
+		return nil
+	}
+	if !ev.LastTimestamp.Time.IsZero() {
+		f.ObservedAt = ev.LastTimestamp.Time
+	} else if !ev.EventTime.Time.IsZero() {
+		f.ObservedAt = ev.EventTime.Time
+	}
+	return f
+}
+
+// containsAny reports whether s contains any of the given substrings.
+// Used by message-based classifiers to keep regex-free, allocation-light dispatch.
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/k8s/failures/classify_test.go
+++ b/k8s/failures/classify_test.go
@@ -1,0 +1,448 @@
+package failures
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// containerStatus is a tiny helper so each test case stays focused on the
+// fields that drive classification.
+func containerStatus(name string, waiting *corev1.ContainerStateWaiting, terminated *corev1.ContainerStateTerminated, lastTerminated *corev1.ContainerStateTerminated) corev1.ContainerStatus {
+	cs := corev1.ContainerStatus{Name: name}
+	cs.State.Waiting = waiting
+	cs.State.Terminated = terminated
+	if lastTerminated != nil {
+		cs.LastTerminationState.Terminated = lastTerminated
+	}
+	return cs
+}
+
+func TestClassifyContainer_Image(t *testing.T) {
+	pod := corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "p"}}
+
+	cases := []struct {
+		name         string
+		waiting      *corev1.ContainerStateWaiting
+		wantName     string
+		wantCategory Category
+		wantProvider Provider
+	}{
+		{
+			name:         "ImagePullBackOff auth",
+			waiting:      &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff", Message: "Error response from daemon: unauthorized: authentication required"},
+			wantName:     "ImagePullBackOff/Auth",
+			wantCategory: CategoryImage,
+			wantProvider: ProviderGeneric,
+		},
+		{
+			name:         "ImagePullBackOff not-found",
+			waiting:      &corev1.ContainerStateWaiting{Reason: "ErrImagePull", Message: "manifest unknown for tag v1.2.3"},
+			wantName:     "ImagePullBackOff/NotFound",
+			wantCategory: CategoryImage,
+			wantProvider: ProviderGeneric,
+		},
+		{
+			name:         "ImagePullBackOff rate-limit",
+			waiting:      &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff", Message: "toomanyrequests: rate limit exceeded"},
+			wantName:     "ImagePullBackOff/RateLimit",
+			wantCategory: CategoryImage,
+			wantProvider: ProviderGeneric,
+		},
+		{
+			name:         "ImagePullBackOff network",
+			waiting:      &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff", Message: "no such host: registry.example.com"},
+			wantName:     "ImagePullBackOff/Network",
+			wantCategory: CategoryImage,
+			wantProvider: ProviderGeneric,
+		},
+		{
+			name:         "ECR auth tags eks",
+			waiting:      &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff", Message: "no basic auth credentials for 1234.dkr.ecr.us-east-1.amazonaws.com/myrepo"},
+			wantName:     "ImagePullBackOff/Auth",
+			wantCategory: CategoryImage,
+			wantProvider: ProviderEKS,
+		},
+		{
+			name:         "ACR auth tags aks",
+			waiting:      &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff", Message: "unauthorized: authentication required pulling from myregistry.azurecr.io"},
+			wantName:     "ImagePullBackOff/Auth",
+			wantCategory: CategoryImage,
+			wantProvider: ProviderAKS,
+		},
+		{
+			name:         "InvalidImageName",
+			waiting:      &corev1.ContainerStateWaiting{Reason: "InvalidImageName", Message: "couldn't parse image reference"},
+			wantName:     "InvalidImageName",
+			wantCategory: CategoryImage,
+			wantProvider: ProviderGeneric,
+		},
+		{
+			name:         "ErrImageNeverPull",
+			waiting:      &corev1.ContainerStateWaiting{Reason: "ErrImageNeverPull"},
+			wantName:     "ErrImageNeverPull",
+			wantCategory: CategoryImage,
+			wantProvider: ProviderGeneric,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClassifyContainer(pod, containerStatus("c", tc.waiting, nil, nil))
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantName, got.Name)
+			assert.Equal(t, tc.wantCategory, got.Category)
+			assert.Equal(t, tc.wantProvider, got.Provider)
+			assert.Equal(t, "c", got.Object.Container)
+		})
+	}
+}
+
+func TestClassifyContainer_Runtime(t *testing.T) {
+	pod := corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "p"}}
+
+	t.Run("CrashLoopBackOff with OOMKilled previous", func(t *testing.T) {
+		got := ClassifyContainer(pod, containerStatus("c",
+			&corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+			nil,
+			&corev1.ContainerStateTerminated{Reason: "OOMKilled", ExitCode: 137},
+		))
+		require.NotNil(t, got)
+		assert.Equal(t, "CrashLoopBackOff/OOMKilled", got.Name)
+		assert.Equal(t, CategoryRuntime, got.Category)
+		assert.Equal(t, "CrashLoopBackOff", got.Signals.WaitingReason)
+		assert.Equal(t, "OOMKilled", got.Signals.TerminatedReason)
+		require.NotNil(t, got.Signals.ExitCode)
+		assert.Equal(t, int32(137), *got.Signals.ExitCode)
+	})
+
+	t.Run("CrashLoopBackOff with exec format error → arch mismatch", func(t *testing.T) {
+		got := ClassifyContainer(pod, containerStatus("c",
+			&corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+			nil,
+			&corev1.ContainerStateTerminated{Message: "standard_init_linux.go:228: exec user process caused: exec format error", ExitCode: 1},
+		))
+		require.NotNil(t, got)
+		assert.Equal(t, "ImageArchitectureMismatch", got.Name)
+		assert.Equal(t, CategoryImage, got.Category)
+	})
+
+	t.Run("CrashLoopBackOff with generic crash", func(t *testing.T) {
+		got := ClassifyContainer(pod, containerStatus("c",
+			&corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+			nil,
+			&corev1.ContainerStateTerminated{Reason: "Error", ExitCode: 1},
+		))
+		require.NotNil(t, got)
+		assert.Equal(t, "CrashLoopBackOff/AppCrash", got.Name)
+		assert.Equal(t, CategoryRuntime, got.Category)
+	})
+
+	t.Run("CrashLoopBackOff without lastState falls back to plain CrashLoopBackOff", func(t *testing.T) {
+		got := ClassifyContainer(pod, containerStatus("c",
+			&corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+			nil, nil,
+		))
+		require.NotNil(t, got)
+		assert.Equal(t, "CrashLoopBackOff", got.Name)
+	})
+
+	t.Run("CreateContainerConfigError", func(t *testing.T) {
+		got := ClassifyContainer(pod, containerStatus("c",
+			&corev1.ContainerStateWaiting{Reason: "CreateContainerConfigError", Message: `secret "db-creds" not found`},
+			nil, nil,
+		))
+		require.NotNil(t, got)
+		assert.Equal(t, "CreateContainerConfigError", got.Name)
+		assert.Equal(t, CategoryRuntime, got.Category)
+	})
+
+	t.Run("Terminated OOMKilled (Job pod)", func(t *testing.T) {
+		got := ClassifyContainer(pod, containerStatus("c", nil,
+			&corev1.ContainerStateTerminated{Reason: "OOMKilled", ExitCode: 137}, nil,
+		))
+		require.NotNil(t, got)
+		assert.Equal(t, "OOMKilled", got.Name)
+	})
+
+	t.Run("Terminated successfully → no failure", func(t *testing.T) {
+		got := ClassifyContainer(pod, containerStatus("c", nil,
+			&corev1.ContainerStateTerminated{Reason: "Completed", ExitCode: 0}, nil,
+		))
+		assert.Nil(t, got)
+	})
+
+	t.Run("Healthy running container → no failure", func(t *testing.T) {
+		got := ClassifyContainer(pod, corev1.ContainerStatus{Name: "c", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}})
+		assert.Nil(t, got)
+	})
+}
+
+func TestClassifyPod_Scheduling(t *testing.T) {
+	pendingPod := func(reason, msg string) corev1.Pod {
+		return corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "p"},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.PodScheduled, Status: corev1.ConditionFalse, Reason: reason, Message: msg},
+				},
+			},
+		}
+	}
+
+	cases := []struct {
+		name         string
+		pod          corev1.Pod
+		wantName     string
+		wantProvider Provider
+	}{
+		{
+			name:         "insufficient cpu",
+			pod:          pendingPod("Unschedulable", "0/3 nodes are available: 3 Insufficient cpu."),
+			wantName:     "FailedScheduling/InsufficientResources",
+			wantProvider: ProviderGeneric,
+		},
+		{
+			name:         "untolerated taint generic",
+			pod:          pendingPod("Unschedulable", "0/3 nodes are available: 3 node(s) had untolerated taint {dedicated: gpu}."),
+			wantName:     "FailedScheduling/UntoleratedTaint",
+			wantProvider: ProviderGeneric,
+		},
+		{
+			name:         "untolerated taint EKS Karpenter",
+			pod:          pendingPod("Unschedulable", "0/2 nodes are available: 2 node(s) had untolerated taint {karpenter.sh/disrupted: true}."),
+			wantName:     "FailedScheduling/UntoleratedTaint",
+			wantProvider: ProviderEKS,
+		},
+		{
+			name:         "node affinity",
+			pod:          pendingPod("Unschedulable", "0/3 nodes are available: 3 node(s) didn't match Pod's node affinity/selector."),
+			wantName:     "FailedScheduling/NodeAffinity",
+			wantProvider: ProviderGeneric,
+		},
+		{
+			name:         "topology spread",
+			pod:          pendingPod("Unschedulable", "0/3 nodes are available: 3 node(s) didn't match pod topology spread constraints."),
+			wantName:     "FailedScheduling/TopologySpread",
+			wantProvider: ProviderGeneric,
+		},
+		{
+			name:         "scheduling gated",
+			pod:          pendingPod("SchedulingGated", `pod has unresolved scheduling gates: ["example.com/gate"]`),
+			wantName:     "SchedulingGated",
+			wantProvider: ProviderGeneric,
+		},
+		{
+			name:         "host port collision",
+			pod:          pendingPod("Unschedulable", "0/3 nodes are available: 3 node(s) didn't have free ports for the requested pod ports."),
+			wantName:     "FailedScheduling/HostPortCollision",
+			wantProvider: ProviderGeneric,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClassifyPod(tc.pod)
+			require.Len(t, got, 1)
+			assert.Equal(t, tc.wantName, got[0].Name)
+			assert.Equal(t, CategoryScheduling, got[0].Category)
+			assert.Equal(t, tc.wantProvider, got[0].Provider)
+		})
+	}
+}
+
+func TestClassifyPod_NodePressure(t *testing.T) {
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "p"},
+		Status: corev1.PodStatus{
+			Phase:   corev1.PodFailed,
+			Reason:  "Evicted",
+			Message: "The node was low on resource: ephemeral-storage. Threshold quantity: 10Gi.",
+		},
+	}
+	got := ClassifyPod(pod)
+	require.Len(t, got, 1)
+	assert.Equal(t, "Evicted/EphemeralStorage", got[0].Name)
+	assert.Equal(t, CategoryNode, got[0].Category)
+}
+
+func TestClassifyEvent(t *testing.T) {
+	makeEvent := func(reason, msg string) corev1.Event {
+		return corev1.Event{
+			InvolvedObject: corev1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "p"},
+			Reason:         reason,
+			Message:        msg,
+			LastTimestamp:  metav1.Time{Time: time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)},
+		}
+	}
+
+	cases := []struct {
+		name         string
+		ev           corev1.Event
+		wantNil      bool
+		wantName     string
+		wantCategory Category
+		wantProvider Provider
+	}{
+		{
+			name:         "FailedCreatePodSandBox EKS IPAM",
+			ev:           makeEvent("FailedCreatePodSandBox", "failed to setup network: InsufficientFreeAddressesInSubnet: subnet-abc has no free addresses"),
+			wantName:     "FailedCreatePodSandBox/IPExhaustion",
+			wantCategory: CategoryNetwork,
+			wantProvider: ProviderEKS,
+		},
+		{
+			name:         "FailedCreatePodSandBox GKE alias range",
+			ev:           makeEvent("FailedCreatePodSandBox", "IP_SPACE_EXHAUSTED on cluster pod range"),
+			wantName:     "FailedCreatePodSandBox/IPExhaustion",
+			wantCategory: CategoryNetwork,
+			wantProvider: ProviderGKE,
+		},
+		{
+			name:         "FailedCreatePodSandBox AKS subnet",
+			ev:           makeEvent("FailedCreatePodSandBox", "Failed to allocate address: SubnetIsFull"),
+			wantName:     "FailedCreatePodSandBox/IPExhaustion",
+			wantCategory: CategoryNetwork,
+			wantProvider: ProviderAKS,
+		},
+		{
+			name:         "FailedMount multi-attach",
+			ev:           makeEvent("FailedMount", "Multi-Attach error for volume pvc-xyz: Volume is already used by pod a/b"),
+			wantName:     "FailedMount/MultiAttach",
+			wantCategory: CategoryStorage,
+			wantProvider: ProviderGeneric,
+		},
+		{
+			name:         "FailedAttachVolume EBS quota",
+			ev:           makeEvent("FailedAttachVolume", "AttachVolume.Attach failed for volume: ebs.csi.aws.com VolumeLimitExceeded"),
+			wantName:     "FailedAttachVolume/VolumeLimit",
+			wantCategory: CategoryStorage,
+			wantProvider: ProviderEKS,
+		},
+		{
+			name:         "FailedCreate quota",
+			ev:           makeEvent("FailedCreate", `Error creating: pods "x-abc" is forbidden: exceeded quota: compute-resources, requested: cpu=2, used: cpu=8, limited: cpu=10`),
+			wantName:     "ResourceQuotaExceeded",
+			wantCategory: CategoryAdmission,
+			wantProvider: ProviderGeneric,
+		},
+		{
+			name:         "FailedCreate PSA",
+			ev:           makeEvent("FailedCreate", `Error creating: pods "x-abc" is forbidden: violates PodSecurity "restricted:v1.28": ...`),
+			wantName:     "PodSecurityDenial",
+			wantCategory: CategoryAdmission,
+			wantProvider: ProviderGeneric,
+		},
+		{
+			name:         "FailedCreate webhook",
+			ev:           makeEvent("FailedCreate", `Error creating: admission webhook "policy.example.com" denied the request: blocked`),
+			wantName:     "AdmissionWebhookDenied",
+			wantCategory: CategoryAdmission,
+			wantProvider: ProviderGeneric,
+		},
+		{
+			name:         "Unhealthy liveness probe",
+			ev:           makeEvent("Unhealthy", "Liveness probe failed: HTTP probe failed with statuscode: 500"),
+			wantName:     "LivenessProbeFailed",
+			wantCategory: CategoryRuntime,
+			wantProvider: ProviderGeneric,
+		},
+		{
+			name:         "Unhealthy readiness probe",
+			ev:           makeEvent("Unhealthy", "Readiness probe failed: dial tcp: connect: connection refused"),
+			wantName:     "ReadinessProbeFailed",
+			wantCategory: CategoryRuntime,
+			wantProvider: ProviderGeneric,
+		},
+		{
+			name:         "FailedScheduling event reuses pending classifier",
+			ev:           makeEvent("FailedScheduling", "0/3 nodes are available: 3 Insufficient memory."),
+			wantName:     "FailedScheduling/InsufficientResources",
+			wantCategory: CategoryScheduling,
+			wantProvider: ProviderGeneric,
+		},
+		{
+			name:    "Unknown reason returns nil",
+			ev:      makeEvent("SomethingWeird", "..."),
+			wantNil: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClassifyEvent(tc.ev)
+			if tc.wantNil {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantName, got.Name)
+			assert.Equal(t, tc.wantCategory, got.Category)
+			assert.Equal(t, tc.wantProvider, got.Provider)
+			assert.Equal(t, tc.ev.LastTimestamp.Time, got.ObservedAt)
+		})
+	}
+}
+
+func TestClassifyDeployment(t *testing.T) {
+	now := metav1.Time{Time: time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)}
+
+	t.Run("ProgressDeadlineExceeded", func(t *testing.T) {
+		d := appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "d"},
+			Status: appsv1.DeploymentStatus{Conditions: []appsv1.DeploymentCondition{{
+				Type: appsv1.DeploymentProgressing, Status: corev1.ConditionFalse,
+				Reason: "ProgressDeadlineExceeded", Message: "deployment exceeded deadline", LastTransitionTime: now,
+			}}},
+		}
+		got := ClassifyDeployment(d)
+		require.Len(t, got, 1)
+		assert.Equal(t, "ProgressDeadlineExceeded", got[0].Name)
+		assert.Equal(t, CategoryRollout, got[0].Category)
+		assert.Equal(t, now.Time, got[0].ObservedAt)
+	})
+
+	t.Run("ReplicaFailure with quota message → ResourceQuotaExceeded", func(t *testing.T) {
+		d := appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "d"},
+			Status: appsv1.DeploymentStatus{Conditions: []appsv1.DeploymentCondition{{
+				Type: appsv1.DeploymentReplicaFailure, Status: corev1.ConditionTrue,
+				Reason:  "FailedCreate",
+				Message: `pods "x-abc" is forbidden: exceeded quota: compute-resources`,
+			}}},
+		}
+		got := ClassifyDeployment(d)
+		require.Len(t, got, 1)
+		assert.Equal(t, "ResourceQuotaExceeded", got[0].Name)
+		assert.Equal(t, CategoryAdmission, got[0].Category)
+		assert.Equal(t, "ReplicaFailure=True:FailedCreate", got[0].Signals.Condition)
+	})
+
+	t.Run("ReplicaFailure with unrecognized message → generic", func(t *testing.T) {
+		d := appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "d"},
+			Status: appsv1.DeploymentStatus{Conditions: []appsv1.DeploymentCondition{{
+				Type: appsv1.DeploymentReplicaFailure, Status: corev1.ConditionTrue,
+				Reason: "FailedCreate", Message: "something nobody has seen before",
+			}}},
+		}
+		got := ClassifyDeployment(d)
+		require.Len(t, got, 1)
+		assert.Equal(t, "ReplicaFailure", got[0].Name)
+		assert.Equal(t, CategoryRollout, got[0].Category)
+	})
+
+	t.Run("Healthy deployment → no failures", func(t *testing.T) {
+		d := appsv1.Deployment{Status: appsv1.DeploymentStatus{Conditions: []appsv1.DeploymentCondition{
+			{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+			{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue},
+		}}}
+		assert.Empty(t, ClassifyDeployment(d))
+	})
+}

--- a/k8s/failures/failure.go
+++ b/k8s/failures/failure.go
@@ -1,0 +1,66 @@
+// Package failures classifies Kubernetes deployment failures into the canonical
+// catalog defined in k8s/failure-modes.md. All classifiers are pure: they take
+// typed snapshots (ContainerStatus, Pod, Event, Deployment) and return a
+// structured Failure record. No API calls.
+package failures
+
+import (
+	"time"
+)
+
+// Category is the top-level catalog section a Failure belongs to.
+type Category string
+
+const (
+	CategoryImage      Category = "image"
+	CategoryRuntime    Category = "runtime"
+	CategoryScheduling Category = "scheduling"
+	CategoryStorage    Category = "storage"
+	CategoryNetwork    Category = "network"
+	CategoryAdmission  Category = "admission"
+	CategoryRollout    Category = "rollout"
+	CategoryNode       Category = "node"
+)
+
+// Provider tags a Failure with the cloud provider it originates from.
+// "generic" means the signal is platform-agnostic.
+type Provider string
+
+const (
+	ProviderGeneric Provider = "generic"
+	ProviderGKE     Provider = "gke"
+	ProviderEKS     Provider = "eks"
+	ProviderAKS     Provider = "aks"
+)
+
+// ObjectRef points at the K8s object the failure was observed on.
+type ObjectRef struct {
+	Kind      string `json:"kind"`
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Container string `json:"container,omitempty"`
+}
+
+// Signals carries the raw evidence that produced the classification.
+// Consumers use it to render drill-down UIs without re-deriving the source.
+type Signals struct {
+	EventReason      string `json:"eventReason,omitempty"`
+	EventMessage     string `json:"eventMessage,omitempty"`
+	WaitingReason    string `json:"waitingReason,omitempty"`
+	TerminatedReason string `json:"terminatedReason,omitempty"`
+	ExitCode         *int32 `json:"exitCode,omitempty"`
+	Condition        string `json:"condition,omitempty"`
+}
+
+// Failure is the structured output of every classifier; matches §12 of failure-modes.md.
+type Failure struct {
+	Name        string    `json:"name"`
+	Category    Category  `json:"category"`
+	Summary     string    `json:"summary"`
+	Remediation string    `json:"remediation"`
+	Object      ObjectRef `json:"object"`
+	Signals     Signals   `json:"signals"`
+	Provider    Provider  `json:"provider"`
+	Docs        []string  `json:"docs,omitempty"`
+	ObservedAt  time.Time `json:"observedAt,omitempty"`
+}

--- a/k8s/failures/image.go
+++ b/k8s/failures/image.go
@@ -1,0 +1,103 @@
+package failures
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// classifyImage handles §1 (Image / Registry) when the trigger is a
+// container's waiting state. Returns nil if the waiting reason isn't image-related.
+func classifyImage(obj ObjectRef, status corev1.ContainerStatus) *Failure {
+	w := status.State.Waiting
+	if w == nil {
+		return nil
+	}
+	switch w.Reason {
+	case "ImagePullBackOff", "ErrImagePull":
+		return imagePullFailure(obj, w.Reason, w.Message)
+	case "InvalidImageName":
+		return &Failure{
+			Name:        "InvalidImageName",
+			Category:    CategoryImage,
+			Summary:     "Image reference is malformed",
+			Remediation: "Fix the spec.containers[].image string (check for whitespace, unexpanded variables, or uppercase host).",
+			Object:      obj,
+			Signals:     Signals{WaitingReason: w.Reason, EventMessage: w.Message},
+			Provider:    ProviderGeneric,
+		}
+	case "ErrImageNeverPull":
+		return &Failure{
+			Name:        "ErrImageNeverPull",
+			Category:    CategoryImage,
+			Summary:     "imagePullPolicy=Never but the image isn't preloaded on the node",
+			Remediation: "Set imagePullPolicy: IfNotPresent, or preload the image on the node.",
+			Object:      obj,
+			Signals:     Signals{WaitingReason: w.Reason, EventMessage: w.Message},
+			Provider:    ProviderGeneric,
+		}
+	case "ImageInspectError":
+		return &Failure{
+			Name:        "ImageInspectError",
+			Category:    CategoryImage,
+			Summary:     "Container runtime could not inspect the image",
+			Remediation: "Re-pull the image or investigate node-local image corruption.",
+			Object:      obj,
+			Signals:     Signals{WaitingReason: w.Reason, EventMessage: w.Message},
+			Provider:    ProviderGeneric,
+		}
+	}
+	return nil
+}
+
+// imagePullFailure sub-classifies ImagePullBackOff/ErrImagePull by parsing the message.
+// Sub-reasons: auth, not-found, rate-limit, network. Defaults to a generic pull failure.
+func imagePullFailure(obj ObjectRef, reason, msg string) *Failure {
+	lower := strings.ToLower(msg)
+	provider := imagePullProvider(lower)
+	f := &Failure{
+		Category: CategoryImage,
+		Object:   obj,
+		Signals:  Signals{WaitingReason: reason, EventMessage: msg},
+		Provider: provider,
+		Docs:     []string{"https://kubernetes.io/docs/concepts/containers/images/#imagepullbackoff"},
+	}
+
+	switch {
+	case containsAny(lower, "unauthorized", "authentication required", "denied", "no basic auth credentials", "401"):
+		f.Name = "ImagePullBackOff/Auth"
+		f.Summary = "Registry rejected credentials (unauthorized)"
+		f.Remediation = "Attach a valid imagePullSecret, refresh expired creds, or grant the cluster identity registry pull permission."
+	case containsAny(lower, "manifest unknown", "not found", "repository does not exist", "name unknown"):
+		f.Name = "ImagePullBackOff/NotFound"
+		f.Summary = "Image tag or repository does not exist"
+		f.Remediation = "Verify the image reference; ensure the tag is pushed."
+	case containsAny(lower, "toomanyrequests", "rate limit", "429"):
+		f.Name = "ImagePullBackOff/RateLimit"
+		f.Summary = "Registry rate-limited the pull (commonly Docker Hub anonymous limits)"
+		f.Remediation = "Authenticate to the registry, mirror the image, or use a registry without per-IP throttling."
+	case containsAny(lower, "no such host", "i/o timeout", "connection refused", "dial tcp", "context deadline exceeded"):
+		f.Name = "ImagePullBackOff/Network"
+		f.Summary = "Could not reach the registry from the node"
+		f.Remediation = "Check egress / DNS from the node; verify the registry hostname; private clusters may need NAT."
+	default:
+		f.Name = "ImagePullBackOff"
+		f.Summary = "Container image could not be pulled"
+		f.Remediation = "Inspect the registry message and verify the image exists and the cluster can authenticate."
+	}
+	return f
+}
+
+// imagePullProvider tags the failure with a provider when the message mentions
+// a provider-specific registry host. Used for the §8.x/§9.6/§10.2 variants.
+func imagePullProvider(lowerMsg string) Provider {
+	switch {
+	case strings.Contains(lowerMsg, ".dkr.ecr."):
+		return ProviderEKS
+	case strings.Contains(lowerMsg, ".azurecr.io"):
+		return ProviderAKS
+	case strings.Contains(lowerMsg, "gcr.io"), strings.Contains(lowerMsg, "pkg.dev"):
+		return ProviderGKE
+	}
+	return ProviderGeneric
+}

--- a/k8s/failures/network.go
+++ b/k8s/failures/network.go
@@ -1,0 +1,157 @@
+package failures
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// classifyNetworkEvent handles §5 (Network) when the trigger is an Event.
+// Right now it covers FailedCreatePodSandBox (§5.1) — the highest-volume class —
+// and SyncLoadBalancerFailed (§5.3).
+func classifyNetworkEvent(obj ObjectRef, ev corev1.Event) *Failure {
+	switch ev.Reason {
+	case "FailedCreatePodSandBox":
+		return sandboxFailure(obj, ev)
+	case "SyncLoadBalancerFailed", "CreatingLoadBalancerFailed":
+		return loadBalancerFailure(obj, ev)
+	case "Unhealthy":
+		// Probe failure events look like:
+		//   "Liveness probe failed: ..." / "Readiness probe failed: ..." / "Startup probe failed: ..."
+		// We label the probe type so the watcher / UI can render it accurately.
+		return probeFailure(obj, ev)
+	}
+	return nil
+}
+
+func sandboxFailure(obj ObjectRef, ev corev1.Event) *Failure {
+	lower := strings.ToLower(ev.Message)
+	signals := Signals{EventReason: ev.Reason, EventMessage: ev.Message}
+
+	switch {
+	case strings.Contains(lower, "insufficientfreeaddressesinsubnet"):
+		// InsufficientFreeAddressesInSubnet is the AWS VPC API error code surfaced
+		// by the EKS VPC CNI; treat it as an EKS-specific signal.
+		return &Failure{
+			Name:        "FailedCreatePodSandBox/IPExhaustion",
+			Category:    CategoryNetwork,
+			Summary:     "VPC subnet has no free IP addresses",
+			Remediation: "Enable prefix delegation, expand the subnet, or use custom networking.",
+			Object:      obj, Signals: signals, Provider: ProviderEKS,
+		}
+	case strings.Contains(lower, "no ip addresses available"):
+		return &Failure{
+			Name:        "FailedCreatePodSandBox/IPExhaustion",
+			Category:    CategoryNetwork,
+			Summary:     "Pod CIDR / subnet has no free IP addresses",
+			Remediation: "Expand the subnet/secondary range or migrate to overlay networking.",
+			Object:      obj,
+			Signals:     signals,
+			Provider:    sandboxProvider(lower),
+		}
+	case strings.Contains(lower, "ip_space_exhausted"):
+		return &Failure{
+			Name:        "FailedCreatePodSandBox/IPExhaustion",
+			Category:    CategoryNetwork,
+			Summary:     "GKE pod IP space exhausted",
+			Remediation: "Add secondary ranges or enable additional pod IP discovery.",
+			Object:      obj, Signals: signals, Provider: ProviderGKE,
+		}
+	case strings.Contains(lower, "subnetisfull"):
+		return &Failure{
+			Name:        "FailedCreatePodSandBox/IPExhaustion",
+			Category:    CategoryNetwork,
+			Summary:     "Azure CNI subnet is full",
+			Remediation: "Migrate to Azure CNI Overlay or expand the subnet.",
+			Object:      obj, Signals: signals, Provider: ProviderAKS,
+		}
+	case strings.Contains(lower, "attachmentlimitexceeded"), strings.Contains(lower, "unable to attach eni"):
+		return &Failure{
+			Name:        "FailedCreatePodSandBox/ENILimit",
+			Category:    CategoryNetwork,
+			Summary:     "Node hit its ENI attachment limit",
+			Remediation: "Use a larger instance type, enable prefix delegation, or reduce ENI usage per pod.",
+			Object:      obj, Signals: signals, Provider: ProviderEKS,
+		}
+	case strings.Contains(lower, "context deadline exceeded"):
+		return &Failure{
+			Name:        "FailedCreatePodSandBox/CNITimeout",
+			Category:    CategoryNetwork,
+			Summary:     "CNI daemon was unresponsive while preparing the sandbox",
+			Remediation: "Check the CNI agent (aws-node, azure-cns, netd) logs on the target node.",
+			Object:      obj, Signals: signals, Provider: sandboxProvider(lower),
+		}
+	}
+	return &Failure{
+		Name:        "FailedCreatePodSandBox",
+		Category:    CategoryNetwork,
+		Summary:     "Container runtime / CNI could not create the pod sandbox",
+		Remediation: "Inspect the CNI message; check node-level networking.",
+		Object:      obj, Signals: signals, Provider: sandboxProvider(lower),
+	}
+}
+
+func sandboxProvider(lowerMsg string) Provider {
+	switch {
+	case strings.Contains(lowerMsg, "vpc cni"), strings.Contains(lowerMsg, "aws-node"), strings.Contains(lowerMsg, "eni"):
+		return ProviderEKS
+	case strings.Contains(lowerMsg, "azure cni"), strings.Contains(lowerMsg, "subnetisfull"):
+		return ProviderAKS
+	case strings.Contains(lowerMsg, "ip_space_exhausted"), strings.Contains(lowerMsg, "alias"):
+		return ProviderGKE
+	}
+	return ProviderGeneric
+}
+
+func loadBalancerFailure(obj ObjectRef, ev corev1.Event) *Failure {
+	lower := strings.ToLower(ev.Message)
+	signals := Signals{EventReason: ev.Reason, EventMessage: ev.Message}
+	provider := loadBalancerProvider(lower)
+	return &Failure{
+		Name:        "LoadBalancerProvisioningFailed",
+		Category:    CategoryNetwork,
+		Summary:     "Cloud load balancer could not be provisioned",
+		Remediation: "Inspect the cloud-controller message; common causes: missing IAM/role, missing subnet tags, exhausted public IP / LB quota.",
+		Object:      obj, Signals: signals, Provider: provider,
+	}
+}
+
+func loadBalancerProvider(lowerMsg string) Provider {
+	switch {
+	case strings.Contains(lowerMsg, "elb"), strings.Contains(lowerMsg, "no matching subnets"), strings.Contains(lowerMsg, "kubernetes.io/role/elb"):
+		return ProviderEKS
+	case strings.Contains(lowerMsg, "publicipcountlimitreached"), strings.Contains(lowerMsg, "outboundrulecannotbeused"):
+		return ProviderAKS
+	case strings.Contains(lowerMsg, "googleapi"), strings.Contains(lowerMsg, "forwardingrules"):
+		return ProviderGKE
+	}
+	return ProviderGeneric
+}
+
+func probeFailure(obj ObjectRef, ev corev1.Event) *Failure {
+	lower := strings.ToLower(ev.Message)
+	probe := "Probe"
+	switch {
+	case strings.HasPrefix(lower, "liveness probe failed"):
+		probe = "Liveness"
+	case strings.HasPrefix(lower, "readiness probe failed"):
+		probe = "Readiness"
+	case strings.HasPrefix(lower, "startup probe failed"):
+		probe = "Startup"
+	}
+	signals := Signals{EventReason: ev.Reason, EventMessage: ev.Message}
+	remediation := "Verify the probe endpoint; widen initialDelaySeconds / failureThreshold or add a startupProbe."
+	if probe == "Readiness" {
+		remediation = "Verify the readiness endpoint; readiness keeps the pod out of Service Endpoints until it passes."
+	}
+	return &Failure{
+		Name:        probe + "ProbeFailed",
+		Category:    CategoryRuntime,
+		Summary:     probe + " probe is failing for the container",
+		Remediation: remediation,
+		Object:      obj,
+		Signals:     signals,
+		Provider:    ProviderGeneric,
+		Docs:        []string{"https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/"},
+	}
+}

--- a/k8s/failures/node.go
+++ b/k8s/failures/node.go
@@ -1,0 +1,57 @@
+package failures
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// classifyNode handles §11 (Node / Infrastructure) signals at the Pod level —
+// specifically Evicted (node pressure) and Preempted. Node-NotReady itself
+// surfaces as a Node-level condition; we don't read Node objects here.
+func classifyNode(obj ObjectRef, pod corev1.Pod) *Failure {
+	if pod.Status.Reason == "Evicted" || strings.Contains(strings.ToLower(pod.Status.Message), "the node was low on resource") {
+		lower := strings.ToLower(pod.Status.Message)
+		name := "Evicted/NodePressure"
+		summary := "Pod was evicted due to node resource pressure"
+		switch {
+		case strings.Contains(lower, "ephemeral-storage"):
+			name = "Evicted/EphemeralStorage"
+			summary = "Pod evicted because the node ran out of ephemeral storage"
+		case strings.Contains(lower, "memory"):
+			name = "Evicted/Memory"
+			summary = "Pod evicted because the node ran low on memory"
+		case strings.Contains(lower, "imagefs"), strings.Contains(lower, "nodefs"):
+			name = "Evicted/DiskPressure"
+			summary = "Pod evicted because the node disk was full"
+		case strings.Contains(lower, "pids"):
+			name = "Evicted/PIDPressure"
+			summary = "Pod evicted because the node ran out of PIDs"
+		}
+		return &Failure{
+			Name:        name,
+			Category:    CategoryNode,
+			Summary:     summary,
+			Remediation: "Set ephemeral-storage limits; reduce log/scratch usage; add capacity or re-balance workloads off the affected node.",
+			Object:      obj,
+			Signals:     Signals{EventReason: pod.Status.Reason, EventMessage: pod.Status.Message},
+			Provider:    ProviderGeneric,
+			Docs:        []string{"https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/"},
+		}
+	}
+
+	for _, c := range pod.Status.Conditions {
+		if c.Type == corev1.DisruptionTarget && c.Status == corev1.ConditionTrue {
+			return &Failure{
+				Name:        "DisruptionTarget/" + c.Reason,
+				Category:    CategoryNode,
+				Summary:     "Pod is targeted for disruption (" + c.Reason + ")",
+				Remediation: "Surface as informational; the controller has decided to terminate this pod.",
+				Object:      obj,
+				Signals:     Signals{Condition: "DisruptionTarget=True:" + c.Reason, EventMessage: c.Message},
+				Provider:    ProviderGeneric,
+			}
+		}
+	}
+	return nil
+}

--- a/k8s/failures/rollout.go
+++ b/k8s/failures/rollout.go
@@ -1,0 +1,54 @@
+package failures
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ClassifyDeployment surfaces §7 (Rollout) signals from a Deployment.
+// Returns 0..N failures; in practice a Deployment can carry both
+// ProgressDeadlineExceeded and ReplicaFailure simultaneously.
+func ClassifyDeployment(d appsv1.Deployment) []Failure {
+	obj := ObjectRef{Kind: "Deployment", Namespace: d.Namespace, Name: d.Name}
+	var out []Failure
+	for _, c := range d.Status.Conditions {
+		switch c.Type {
+		case appsv1.DeploymentProgressing:
+			if c.Status == corev1.ConditionFalse && c.Reason == "ProgressDeadlineExceeded" {
+				out = append(out, Failure{
+					Name:        "ProgressDeadlineExceeded",
+					Category:    CategoryRollout,
+					Summary:     "Deployment exceeded its progressDeadlineSeconds without completing",
+					Remediation: "Drill into the newest ReplicaSet's pods to find the underlying failure (image, scheduling, probes, admission).",
+					Object:      obj,
+					Signals:     Signals{Condition: "Progressing=False:ProgressDeadlineExceeded", EventMessage: c.Message},
+					Provider:    ProviderGeneric,
+					Docs:        []string{"https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#failed-deployment"},
+					ObservedAt:  c.LastTransitionTime.Time,
+				})
+			}
+		case appsv1.DeploymentReplicaFailure:
+			if c.Status == corev1.ConditionTrue {
+				// ReplicaFailure messages are usually admission-shaped (quota / webhook /
+				// PSA). Try the admission classifier first so the canonical name matches.
+				if f := classifyAdmissionMessage(obj, c.Reason, c.Message); f != nil {
+					f.Signals.Condition = "ReplicaFailure=True:" + c.Reason
+					f.ObservedAt = c.LastTransitionTime.Time
+					out = append(out, *f)
+					continue
+				}
+				out = append(out, Failure{
+					Name:        "ReplicaFailure",
+					Category:    CategoryRollout,
+					Summary:     "Deployment cannot create new pods",
+					Remediation: "Inspect the condition message; common causes: quota, admission webhook, PSA, missing ServiceAccount.",
+					Object:      obj,
+					Signals:     Signals{Condition: "ReplicaFailure=True:" + c.Reason, EventMessage: c.Message},
+					Provider:    ProviderGeneric,
+					ObservedAt:  c.LastTransitionTime.Time,
+				})
+			}
+		}
+	}
+	return out
+}

--- a/k8s/failures/runtime.go
+++ b/k8s/failures/runtime.go
@@ -1,0 +1,169 @@
+package failures
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// classifyRuntime handles §2 (Runtime / Container Lifecycle).
+// Pulls from both state.waiting (current state) and lastState.terminated
+// (previous instance) so OOMKilled / app-crash variants of CrashLoopBackOff
+// can be distinguished.
+func classifyRuntime(obj ObjectRef, status corev1.ContainerStatus) *Failure {
+	if f := classifyTerminated(obj, status); f != nil {
+		return f
+	}
+	w := status.State.Waiting
+	if w == nil {
+		return nil
+	}
+	switch w.Reason {
+	case "CrashLoopBackOff":
+		return crashLoop(obj, status)
+	case "CreateContainerConfigError":
+		return &Failure{
+			Name:        "CreateContainerConfigError",
+			Category:    CategoryRuntime,
+			Summary:     "Pod references a missing ConfigMap, Secret, or key",
+			Remediation: "Create the referenced object/key, or mark the source `optional: true`.",
+			Object:      obj,
+			Signals:     Signals{WaitingReason: w.Reason, EventMessage: w.Message},
+			Provider:    ProviderGeneric,
+		}
+	case "CreateContainerError":
+		return &Failure{
+			Name:        "CreateContainerError",
+			Category:    CategoryRuntime,
+			Summary:     "Container runtime rejected the container spec",
+			Remediation: "Inspect the runtime message — common causes: invalid mount, denied hostPath, missing seccomp profile, or post-crash name collision.",
+			Object:      obj,
+			Signals:     Signals{WaitingReason: w.Reason, EventMessage: w.Message},
+			Provider:    ProviderGeneric,
+		}
+	case "RunContainerError":
+		return &Failure{
+			Name:        "RunContainerError",
+			Category:    CategoryRuntime,
+			Summary:     "Container runtime failed to start the entrypoint",
+			Remediation: "Verify the entrypoint exists and is executable in the image; check for arch mismatch.",
+			Object:      obj,
+			Signals:     Signals{WaitingReason: w.Reason, EventMessage: w.Message},
+			Provider:    ProviderGeneric,
+		}
+	case "ContainerCannotRun":
+		return &Failure{
+			Name:        "ContainerCannotRun",
+			Category:    CategoryRuntime,
+			Summary:     "Container runtime refused to run the container",
+			Remediation: "Inspect the runtime message for specifics (entrypoint, capabilities, mount).",
+			Object:      obj,
+			Signals:     Signals{WaitingReason: w.Reason, EventMessage: w.Message},
+			Provider:    ProviderGeneric,
+		}
+	}
+	return nil
+}
+
+// classifyTerminated handles the case where the *current* state is Terminated
+// (typically a Job pod or a non-restarting container). It is also used during
+// CrashLoopBackOff to interpret lastState.
+func classifyTerminated(obj ObjectRef, status corev1.ContainerStatus) *Failure {
+	t := status.State.Terminated
+	if t == nil {
+		return nil
+	}
+	if t.Reason == "Completed" || (t.ExitCode == 0 && t.Reason == "") {
+		return nil
+	}
+	return terminationFailure(obj, *t, false)
+}
+
+// crashLoop interprets a container stuck in CrashLoopBackOff by looking at its
+// previous (terminated) state. Without lastState, we can still report the loop
+// itself; with lastState we can pinpoint OOMKilled vs app crash vs probe-killed.
+func crashLoop(obj ObjectRef, status corev1.ContainerStatus) *Failure {
+	w := status.State.Waiting // already non-nil per caller
+	last := status.LastTerminationState.Terminated
+	if last != nil {
+		if f := terminationFailure(obj, *last, true); f != nil {
+			f.Signals.WaitingReason = w.Reason
+			return f
+		}
+	}
+	return &Failure{
+		Name:        "CrashLoopBackOff",
+		Category:    CategoryRuntime,
+		Summary:     "Container repeatedly exits and is being backed off",
+		Remediation: "Inspect previous-container logs (kubectl logs --previous) and fix the startup path.",
+		Object:      obj,
+		Signals:     Signals{WaitingReason: w.Reason, EventMessage: w.Message},
+		Provider:    ProviderGeneric,
+		Docs:        []string{"https://kubernetes.io/docs/tasks/debug/debug-application/debug-pods/"},
+	}
+}
+
+// terminationFailure classifies a single termination event (current Terminated or
+// LastTerminationState). `inLoop` distinguishes a one-shot terminal from a CrashLoop ancestor.
+func terminationFailure(obj ObjectRef, t corev1.ContainerStateTerminated, inLoop bool) *Failure {
+	exit := t.ExitCode
+	signals := Signals{TerminatedReason: t.Reason, ExitCode: &exit, EventMessage: t.Message}
+
+	// OOMKilled is structurally distinct — kubelet sets reason directly.
+	if t.Reason == "OOMKilled" {
+		name := "OOMKilled"
+		summary := "Container exceeded its memory limit and was killed by the kernel OOM killer"
+		if inLoop {
+			name = "CrashLoopBackOff/OOMKilled"
+			summary = "Container repeatedly OOM-killed; loop continues"
+		}
+		return &Failure{
+			Name:        name,
+			Category:    CategoryRuntime,
+			Summary:     summary,
+			Remediation: "Raise resources.limits.memory, fix the leak, or size the runtime heap (GOMEMLIMIT, -XX:MaxRAMPercentage).",
+			Object:      obj,
+			Signals:     signals,
+			Provider:    ProviderGeneric,
+			Docs:        []string{"https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"},
+		}
+	}
+
+	// Architecture mismatch: kubelet message often contains "exec format error".
+	if strings.Contains(strings.ToLower(t.Message), "exec format error") {
+		return &Failure{
+			Name:        "ImageArchitectureMismatch",
+			Category:    CategoryImage,
+			Summary:     "Image architecture does not match the node (amd64 vs arm64)",
+			Remediation: "Publish a multi-arch manifest (docker buildx --platform) or pin nodeSelector kubernetes.io/arch.",
+			Object:      obj,
+			Signals:     signals,
+			Provider:    ProviderGeneric,
+		}
+	}
+
+	// Generic crash. Exit code carries the signal in the loop case.
+	name := "ContainerExited"
+	summary := "Container exited unexpectedly"
+	if inLoop {
+		name = "CrashLoopBackOff/AppCrash"
+		summary = "Container repeatedly crashes on startup"
+	}
+	switch exit {
+	case 137:
+		summary = "Container received SIGKILL (often a precursor to OOMKilled)"
+	case 139:
+		summary = "Container segfaulted (SIGSEGV)"
+	case 143:
+		summary = "Container received SIGTERM and did not exit gracefully"
+	}
+	return &Failure{
+		Name:        name,
+		Category:    CategoryRuntime,
+		Summary:     summary,
+		Remediation: "Check previous-container logs for the underlying exception or signal source.",
+		Object:      obj,
+		Signals:     signals,
+		Provider:    ProviderGeneric,
+	}
+}

--- a/k8s/failures/scheduling.go
+++ b/k8s/failures/scheduling.go
@@ -1,0 +1,152 @@
+package failures
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// classifyPending handles §3 (Scheduling) by interpreting Pod.status.conditions
+// when the pod is stuck in Pending. Returns nil for pods that aren't pending or
+// whose PodScheduled condition isn't reporting a recognized failure.
+func classifyPending(obj ObjectRef, pod corev1.Pod) *Failure {
+	if pod.Status.Phase != corev1.PodPending {
+		return nil
+	}
+	for _, c := range pod.Status.Conditions {
+		if c.Type != corev1.PodScheduled || c.Status == corev1.ConditionTrue {
+			continue
+		}
+		switch c.Reason {
+		case "Unschedulable":
+			return classifySchedulingMessage(obj, c.Message)
+		case "SchedulingGated":
+			return &Failure{
+				Name:        "SchedulingGated",
+				Category:    CategoryScheduling,
+				Summary:     "Pod has unresolved schedulingGates set by an external controller",
+				Remediation: "The controller that owns the gate (Kueue, Karpenter, etc.) hasn't cleared it yet — investigate that controller.",
+				Object:      obj,
+				Signals:     Signals{Condition: "PodScheduled=False:SchedulingGated", EventMessage: c.Message},
+				Provider:    ProviderGeneric,
+			}
+		}
+	}
+	return nil
+}
+
+// classifySchedulingMessage interprets a kube-scheduler "Unschedulable" message
+// (e.g. "0/3 nodes are available: 3 Insufficient cpu") into a specific bucket.
+func classifySchedulingMessage(obj ObjectRef, msg string) *Failure {
+	lower := strings.ToLower(msg)
+	signals := Signals{Condition: "PodScheduled=False:Unschedulable", EventReason: "FailedScheduling", EventMessage: msg}
+
+	switch {
+	case containsAny(lower, "insufficient cpu", "insufficient memory", "insufficient ephemeral-storage", "insufficient pods"):
+		return &Failure{
+			Name:        "FailedScheduling/InsufficientResources",
+			Category:    CategoryScheduling,
+			Summary:     "No node has enough capacity for the pod's resource requests",
+			Remediation: "Reduce requests, add nodes, or enable cluster autoscaler.",
+			Object:      obj,
+			Signals:     signals,
+			Provider:    ProviderGeneric,
+			Docs:        []string{"https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/"},
+		}
+	case strings.Contains(lower, "untolerated taint"), strings.Contains(lower, "had taint"):
+		f := &Failure{
+			Name:        "FailedScheduling/UntoleratedTaint",
+			Category:    CategoryScheduling,
+			Summary:     "Available nodes carry a taint the pod doesn't tolerate",
+			Remediation: "Add a matching toleration or schedule onto a different node pool.",
+			Object:      obj,
+			Signals:     signals,
+			Provider:    schedulingTaintProvider(lower),
+		}
+		return f
+	case strings.Contains(lower, "node affinity"), strings.Contains(lower, "node selector"), strings.Contains(lower, "didn't match pod's node affinity/selector"):
+		return &Failure{
+			Name:        "FailedScheduling/NodeAffinity",
+			Category:    CategoryScheduling,
+			Summary:     "No node matches the pod's nodeAffinity / nodeSelector",
+			Remediation: "Align node labels (e.g. topology.kubernetes.io/zone, kubernetes.io/arch) or relax the affinity to preferredDuringScheduling.",
+			Object:      obj,
+			Signals:     signals,
+			Provider:    ProviderGeneric,
+		}
+	case strings.Contains(lower, "didn't match pod affinity"), strings.Contains(lower, "didn't match pod anti-affinity"):
+		return &Failure{
+			Name:        "FailedScheduling/PodAffinity",
+			Category:    CategoryScheduling,
+			Summary:     "Pod (anti-)affinity cannot be satisfied by the cluster topology",
+			Remediation: "Reduce the constraint or add capacity that satisfies it; consider preferredDuringScheduling.",
+			Object:      obj,
+			Signals:     signals,
+			Provider:    ProviderGeneric,
+		}
+	case strings.Contains(lower, "topology spread"):
+		return &Failure{
+			Name:        "FailedScheduling/TopologySpread",
+			Category:    CategoryScheduling,
+			Summary:     "Topology spread constraints cannot be satisfied",
+			Remediation: "Loosen maxSkew, add capacity in the missing topology, or change to ScheduleAnyway.",
+			Object:      obj,
+			Signals:     signals,
+			Provider:    ProviderGeneric,
+		}
+	case strings.Contains(lower, "free ports"):
+		return &Failure{
+			Name:        "FailedScheduling/HostPortCollision",
+			Category:    CategoryScheduling,
+			Summary:     "No node has the requested hostPort free",
+			Remediation: "Drop hostPort if not required, or pick a port not already bound on candidate nodes.",
+			Object:      obj,
+			Signals:     signals,
+			Provider:    ProviderGeneric,
+		}
+	case strings.Contains(lower, "too many pods"):
+		return &Failure{
+			Name:        "FailedScheduling/MaxPodsExceeded",
+			Category:    CategoryScheduling,
+			Summary:     "Candidate nodes are at their max-pods cap",
+			Remediation: "Use larger instance types, raise kubelet --max-pods, or add nodes.",
+			Object:      obj,
+			Signals:     signals,
+			Provider:    ProviderGeneric,
+		}
+	case strings.Contains(lower, "insufficient nvidia.com/gpu"), strings.Contains(lower, "insufficient amd.com/gpu"):
+		return &Failure{
+			Name:        "FailedScheduling/ExtendedResource",
+			Category:    CategoryScheduling,
+			Summary:     "Requested extended resource (e.g. GPU) is not advertised on any node",
+			Remediation: "Install the device plugin or add a node pool that exposes the resource.",
+			Object:      obj,
+			Signals:     signals,
+			Provider:    ProviderGeneric,
+		}
+	}
+
+	return &Failure{
+		Name:        "FailedScheduling",
+		Category:    CategoryScheduling,
+		Summary:     "Scheduler could not place the pod on any node",
+		Remediation: "Inspect the scheduler message for the specific constraint that failed.",
+		Object:      obj,
+		Signals:     signals,
+		Provider:    ProviderGeneric,
+	}
+}
+
+// schedulingTaintProvider tags untolerated-taint failures by recognizing
+// provider-specific taint keys in the scheduler message. (See §3.2.)
+func schedulingTaintProvider(lowerMsg string) Provider {
+	switch {
+	case strings.Contains(lowerMsg, "cloud.google.com/gke-"), strings.Contains(lowerMsg, "components.gke.io/"):
+		return ProviderGKE
+	case strings.Contains(lowerMsg, "eks.amazonaws.com/"), strings.Contains(lowerMsg, "karpenter.sh/"):
+		return ProviderEKS
+	case strings.Contains(lowerMsg, "kubernetes.azure.com/"), strings.Contains(lowerMsg, "criticaladdonsonly"):
+		return ProviderAKS
+	}
+	return ProviderGeneric
+}

--- a/k8s/failures/storage.go
+++ b/k8s/failures/storage.go
@@ -1,0 +1,122 @@
+package failures
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// classifyVolumeEvent handles §4 (Storage) when the trigger is an Event with a
+// volume-related reason. PVC-Pending and StatefulSet-stuck cases are surfaced
+// via the same path because they emit FailedMount/FailedAttachVolume events.
+func classifyVolumeEvent(obj ObjectRef, ev corev1.Event) *Failure {
+	switch ev.Reason {
+	case "FailedMount":
+		return mountFailure(obj, ev, "FailedMount")
+	case "FailedAttachVolume":
+		return mountFailure(obj, ev, "FailedAttachVolume")
+	case "ProvisioningFailed", "FailedBinding":
+		return &Failure{
+			Name:        "PVCProvisioningFailed",
+			Category:    CategoryStorage,
+			Summary:     "PVC could not be provisioned by its StorageClass",
+			Remediation: "Check the StorageClass exists and the cloud disk quota / zone is correct; prefer volumeBindingMode: WaitForFirstConsumer for zonal volumes.",
+			Object:      obj,
+			Signals:     Signals{EventReason: ev.Reason, EventMessage: ev.Message},
+			Provider:    storageProvider(ev.Message),
+			Docs:        []string{"https://kubernetes.io/docs/concepts/storage/persistent-volumes/"},
+		}
+	case "VolumeResizeFailed":
+		return &Failure{
+			Name:        "VolumeResizeFailed",
+			Category:    CategoryStorage,
+			Summary:     "Online volume resize failed",
+			Remediation: "Inspect the CSI driver logs; some drivers require a pod restart for FS expansion.",
+			Object:      obj,
+			Signals:     Signals{EventReason: ev.Reason, EventMessage: ev.Message},
+			Provider:    storageProvider(ev.Message),
+		}
+	}
+	return nil
+}
+
+// mountFailure sub-classifies FailedMount / FailedAttachVolume by message content.
+// Provider tag comes from message keywords (EBS / Azure Disk / GCE PD).
+func mountFailure(obj ObjectRef, ev corev1.Event, reason string) *Failure {
+	lower := strings.ToLower(ev.Message)
+	signals := Signals{EventReason: reason, EventMessage: ev.Message}
+	provider := storageProvider(ev.Message)
+
+	switch {
+	case strings.Contains(lower, "multi-attach error"):
+		return &Failure{
+			Name:        reason + "/MultiAttach",
+			Category:    CategoryStorage,
+			Summary:     "RWO volume is still attached to a previous node",
+			Remediation: "Wait for the prior pod to terminate; consider force-detach if the previous node is gone.",
+			Object:      obj, Signals: signals, Provider: provider,
+		}
+	case strings.Contains(lower, "volumelimitexceeded"):
+		return &Failure{
+			Name:        reason + "/VolumeLimit",
+			Category:    CategoryStorage,
+			Summary:     "Node has hit its per-instance attached-volume cap",
+			Remediation: "Schedule onto a larger instance type, or reduce volumes per pod.",
+			Object:      obj, Signals: signals, Provider: provider,
+		}
+	case strings.Contains(lower, "unauthorizedoperation"), strings.Contains(lower, "authorizationfailed"), strings.Contains(lower, "requires one of"):
+		return &Failure{
+			Name:        reason + "/IAM",
+			Category:    CategoryStorage,
+			Summary:     "Cloud IAM does not grant the cluster permission to attach the disk",
+			Remediation: "Grant the node/cluster identity the appropriate role (EBS attach, Compute disk attach, Network Contributor).",
+			Object:      obj, Signals: signals, Provider: provider,
+		}
+	case strings.Contains(lower, "quota_exceeded"), strings.Contains(lower, "quota exceeded"):
+		return &Failure{
+			Name:        reason + "/Quota",
+			Category:    CategoryStorage,
+			Summary:     "Cloud disk quota exceeded",
+			Remediation: "Request a quota increase or release unused disks.",
+			Object:      obj, Signals: signals, Provider: provider,
+		}
+	case strings.Contains(lower, "does not exist"):
+		return &Failure{
+			Name:        reason + "/Missing",
+			Category:    CategoryStorage,
+			Summary:     "Underlying disk no longer exists",
+			Remediation: "Restore from snapshot, or recreate the PV/PVC.",
+			Object:      obj, Signals: signals, Provider: provider,
+		}
+	case strings.Contains(lower, "timed out waiting for the condition"):
+		return &Failure{
+			Name:        reason + "/Timeout",
+			Category:    CategoryStorage,
+			Summary:     "CSI driver timed out attaching/mounting the volume",
+			Remediation: "Inspect the CSI controller pod logs; check cloud-side queue for the disk operation.",
+			Object:      obj, Signals: signals, Provider: provider,
+		}
+	}
+	return &Failure{
+		Name:        reason,
+		Category:    CategoryStorage,
+		Summary:     "Volume could not be attached/mounted",
+		Remediation: "Inspect the CSI driver logs and the underlying cloud volume state.",
+		Object:      obj, Signals: signals, Provider: provider,
+	}
+}
+
+// storageProvider tags storage failures by recognizing provider keywords in the
+// event message (azure / disk.csi.azure.com / ebs.csi.aws.com / pd.csi.storage.gke.io).
+func storageProvider(msg string) Provider {
+	lower := strings.ToLower(msg)
+	switch {
+	case strings.Contains(lower, "ebs.csi.aws.com"), strings.Contains(lower, "ebs"):
+		return ProviderEKS
+	case strings.Contains(lower, "disk.csi.azure.com"), strings.Contains(lower, "azure"):
+		return ProviderAKS
+	case strings.Contains(lower, "pd.csi.storage.gke.io"), strings.Contains(lower, "gce-pd"):
+		return ProviderGKE
+	}
+	return ProviderGeneric
+}

--- a/k8s/log_streamer.go
+++ b/k8s/log_streamer.go
@@ -22,17 +22,16 @@ func (l LogStreamer) Stream(ctx context.Context, options app.LogStreamOptions) e
 	if options.Emitter == nil {
 		options.Emitter = app.NewWriterLogEmitter(os.Stdout)
 	}
-	selector := fmt.Sprintf("nullstone.io/app=%s", l.AppName)
-	if options.Selector != nil && *options.Selector != "" {
-		selector = *options.Selector
-	}
+	options.Selectors = append([]string{
+		fmt.Sprintf("nullstone.io/app=%s", l.AppName)},
+		options.Selectors...,
+	)
 
 	streamer := logs.WorkloadStreamer{
 		Namespace:    l.AppNamespace,
 		WorkloadName: l.AppName,
 		NewConfigFn:  l.NewConfigFn,
 		Options:      options,
-		Selector:     selector,
 	}
 	return streamer.Stream(ctx)
 }

--- a/k8s/logs/workload_streamer.go
+++ b/k8s/logs/workload_streamer.go
@@ -3,6 +3,7 @@ package logs
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -25,10 +26,10 @@ type WorkloadStreamer struct {
 	WorkloadName string
 	NewConfigFn  NewConfiger
 	Options      app.LogStreamOptions
-	Selector     string
 }
 
 func (s *WorkloadStreamer) Stream(ctx context.Context) error {
+	selector := strings.Join(s.Options.Selectors, ",")
 	buffer := &SimpleLogBuffer{Emitter: s.Options.Emitter}
 
 	// Prepare a safe channel to signal
@@ -57,7 +58,7 @@ func (s *WorkloadStreamer) Stream(ctx context.Context) error {
 		return s.newInitError("There was an error initializing kubernetes client", err)
 	}
 
-	podList, err := client.CoreV1().Pods(s.Namespace).List(ctx, metav1.ListOptions{LabelSelector: s.Selector})
+	podList, err := client.CoreV1().Pods(s.Namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
 		return s.newInitError("Failed to list pods", err)
 	}
@@ -72,11 +73,15 @@ func (s *WorkloadStreamer) Stream(ctx context.Context) error {
 	}
 	// Add pods that already exist
 	for _, pod := range podList.Items {
+		if s.Options.Pod != "" && s.Options.Pod != pod.Name {
+			s.debug(fmt.Sprintf("Ignore pod that doesn't match filter (%s)...", pod.Name))
+			continue
+		}
 		s.debug(fmt.Sprintf("Adding pod (%s)...", pod.Name))
 		streamers.Add(ctx, &pod, s.Options, buffer)
 	}
 
-	watcher, err := client.CoreV1().Pods(s.Namespace).Watch(ctx, metav1.ListOptions{LabelSelector: s.Selector, ResourceVersion: podList.ResourceVersion})
+	watcher, err := client.CoreV1().Pods(s.Namespace).Watch(ctx, metav1.ListOptions{LabelSelector: selector, ResourceVersion: podList.ResourceVersion})
 	if err != nil {
 		return s.newInitError("Failed to watch pods", err)
 	}

--- a/k8s/status.go
+++ b/k8s/status.go
@@ -9,6 +9,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const (
+	PodTemplateHashLabel = "pod-template-hash"
+)
+
 // ClusterInfo identifies the cloud cluster an app is running on. Distinct from
 // the ClusterInfoer interface (which produces kube-config Cluster details for
 // auth) — this carries the human/cloud-provider identifiers used in status output.
@@ -32,6 +36,7 @@ type AppStatus struct {
 
 type AppStatusReplicaSet struct {
 	Name              string                    `json:"name"`
+	PodTemplateHash   string                    `json:"podTemplateHash"`
 	Revision          int                       `json:"revision"`
 	Generation        int64                     `json:"generation"`
 	AppVersion        string                    `json:"appVersion"`
@@ -53,6 +58,7 @@ func AppStatusReplicaSetFromK8s(rs appsv1.ReplicaSet, svcs []corev1.Service) App
 
 	return AppStatusReplicaSet{
 		Name:              rs.Name,
+		PodTemplateHash:   rs.Labels[PodTemplateHashLabel],
 		Revision:          RevisionFromReplicaSet(rs),
 		Generation:        rs.Status.ObservedGeneration,
 		AppVersion:        rs.Labels[StandardVersionLabel],

--- a/k8s/status.go
+++ b/k8s/status.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/nullstone-io/deployment-sdk/k8s/failures"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -23,6 +24,10 @@ type AppStatus struct {
 	DeploymentName string                  `json:"deploymentName"`
 	ReplicaSets    []AppStatusReplicaSet   `json:"replicaSets"`
 	Jobs           []AppStatusJobExecution `json:"jobs"`
+	// Failures aggregates rollout-level failures (Deployment ProgressDeadlineExceeded,
+	// ReplicaFailure conditions). Container and pod-level failures live on their
+	// respective entries inside ReplicaSets.
+	Failures []failures.Failure `json:"failures,omitempty"`
 }
 
 type AppStatusReplicaSet struct {
@@ -118,6 +123,9 @@ type AppStatusPod struct {
 	MaxRestartCount int `json:"maxRestartCount"`
 	// LastRestartedAt is the LastRestartedAt of the container with MaxRestartCount, or nil if no container has restarted.
 	LastRestartedAt *time.Time `json:"lastRestartedAt"`
+	// Failures aggregates pod-level classification (scheduling, eviction).
+	// Container-level classification lives on each AppStatusPodContainer.Failure.
+	Failures []failures.Failure `json:"failures,omitempty"`
 }
 
 type AppStatusPodCondition struct {
@@ -135,7 +143,11 @@ func AppStatusPodFromK8s(pod corev1.Pod, svcs []corev1.Service) AppStatusPod {
 	maxRestartCount := 0
 	var lastRestartedAt *time.Time
 	for _, cur := range pod.Spec.Containers {
-		container := AppStatusContainerFromK8s(cur, findPodContainerStatus(pod, cur), svcs)
+		status := findPodContainerStatus(pod, cur)
+		container := AppStatusContainerFromK8s(cur, status, svcs)
+		if status != nil {
+			container.Failure = failures.ClassifyContainer(pod, *status)
+		}
 		containers = append(containers, container)
 		if container.RestartCount > maxRestartCount {
 			maxRestartCount = container.RestartCount
@@ -174,6 +186,7 @@ func AppStatusPodFromK8s(pod corev1.Pod, svcs []corev1.Service) AppStatusPod {
 		Conditions:      conditions,
 		MaxRestartCount: maxRestartCount,
 		LastRestartedAt: lastRestartedAt,
+		Failures:        failures.ClassifyPod(pod),
 	}
 }
 
@@ -188,6 +201,9 @@ type AppStatusPodContainer struct {
 	// or nil if the container has never restarted.
 	LastRestartedAt *time.Time                  `json:"lastRestartedAt"`
 	Ports           []AppStatusPodContainerPort `json:"ports"`
+	// Failure is the classified failure for this container, if any.
+	// Populated by failures.ClassifyContainer; nil when healthy.
+	Failure *failures.Failure `json:"failure,omitempty"`
 }
 
 func AppStatusContainerFromK8s(container corev1.Container, status *corev1.ContainerStatus, svcs []corev1.Service) AppStatusPodContainer {

--- a/k8s/statuser.go
+++ b/k8s/statuser.go
@@ -6,10 +6,12 @@ import (
 	"sync"
 
 	"github.com/nullstone-io/deployment-sdk/app"
+	"github.com/nullstone-io/deployment-sdk/k8s/failures"
 	"github.com/nullstone-io/deployment-sdk/logging"
 	"k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -140,6 +142,17 @@ func (s *Statuser) Status(ctx context.Context) (any, error) {
 	for _, job := range s.jobs {
 		st.Jobs = append(st.Jobs, AppStatusJobExecutionFromK8s(job))
 	}
+
+	// Surface rollout-level failures (ProgressDeadlineExceeded / ReplicaFailure)
+	// from the parent Deployment when one exists with the app name. A missing
+	// Deployment isn't an error — some app types may not have one — so we ignore
+	// NotFound and any transient classification miss.
+	if dep, err := s.client.AppsV1().Deployments(s.AppNamespace).Get(ctx, s.AppName, metav1.GetOptions{}); err == nil && dep != nil {
+		st.Failures = failures.ClassifyDeployment(*dep)
+	} else if err != nil && !apierrors.IsNotFound(err) {
+		return st, fmt.Errorf("error retrieving app deployment: %w", err)
+	}
+
 	return st, nil
 }
 


### PR DESCRIPTION
Added failure mode detection to k8s workloads.
Failures are detected on Deployment, Pod, and Container.

These failures are reported via Statuser and DeployWatcher.

The catalog of failure modes is comprehensive and includes platform-specific failures for AWS and GCP.

This pull request also includes: https://github.com/nullstone-io/deployment-sdk/pull/131