### PR TITLE
Feat/30/ws actions

### DIFF
--- a/aws/eks/actioner.go
+++ b/aws/eks/actioner.go
@@ -1,0 +1,34 @@
+package eks
+
+import (
+	"context"
+
+	"github.com/nullstone-io/deployment-sdk/aws/creds"
+	"github.com/nullstone-io/deployment-sdk/k8s"
+	"github.com/nullstone-io/deployment-sdk/logging"
+	"github.com/nullstone-io/deployment-sdk/outputs"
+	"github.com/nullstone-io/deployment-sdk/workspace"
+	"gopkg.in/nullstone-io/go-api-client.v0/types"
+	"k8s.io/client-go/rest"
+)
+
+func NewActioner(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, blockDetails workspace.Details) (workspace.Actioner, error) {
+	outs, err := outputs.Retrieve[Outputs](ctx, source, blockDetails.Workspace, blockDetails.WorkspaceConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	ws := blockDetails.Workspace
+	credsFactory := creds.NewProviderFactory(source, ws.StackId, ws.BlockId, ws.EnvId)
+	outs.Deployer.RemoteProvider = credsFactory(types.AutomationPurposePerformAction, "deployer")
+
+	return k8s.Actioner{
+		OsWriters:         osWriters,
+		Namespace:         outs.ServiceNamespace,
+		AppName:           blockDetails.Block.Name,
+		JobDefinitionName: outs.JobDefinitionName,
+		NewConfigFn: func(ctx context.Context) (*rest.Config, error) {
+			return CreateKubeConfig(ctx, outs.ClusterNamespace, outs.Deployer)
+		},
+	}, nil
+}

--- a/aws/eks/actioner.go
+++ b/aws/eks/actioner.go
@@ -23,10 +23,9 @@ func NewActioner(ctx context.Context, osWriters logging.OsWriters, source output
 	outs.Deployer.RemoteProvider = credsFactory(types.AutomationPurposePerformAction, "deployer")
 
 	return k8s.Actioner{
-		OsWriters:         osWriters,
-		Namespace:         outs.ServiceNamespace,
-		AppName:           blockDetails.Block.Name,
-		JobDefinitionName: outs.JobDefinitionName,
+		OsWriters: osWriters,
+		Namespace: outs.ServiceNamespace,
+		AppName:   blockDetails.Block.Name,
 		NewConfigFn: func(ctx context.Context) (*rest.Config, error) {
 			return CreateKubeConfig(ctx, outs.ClusterNamespace, outs.Deployer)
 		},

--- a/aws/eks/actioner.go
+++ b/aws/eks/actioner.go
@@ -5,14 +5,13 @@ import (
 
 	"github.com/nullstone-io/deployment-sdk/aws/creds"
 	"github.com/nullstone-io/deployment-sdk/k8s"
-	"github.com/nullstone-io/deployment-sdk/logging"
 	"github.com/nullstone-io/deployment-sdk/outputs"
 	"github.com/nullstone-io/deployment-sdk/workspace"
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
 	"k8s.io/client-go/rest"
 )
 
-func NewActioner(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, blockDetails workspace.Details) (workspace.Actioner, error) {
+func NewActioner(ctx context.Context, source outputs.RetrieverSource, blockDetails workspace.Details) (workspace.Actioner, error) {
 	outs, err := outputs.Retrieve[Outputs](ctx, source, blockDetails.Workspace, blockDetails.WorkspaceConfig)
 	if err != nil {
 		return nil, err
@@ -23,7 +22,6 @@ func NewActioner(ctx context.Context, osWriters logging.OsWriters, source output
 	outs.Deployer.RemoteProvider = credsFactory(types.AutomationPurposePerformAction, "deployer")
 
 	return k8s.Actioner{
-		OsWriters: osWriters,
 		Namespace: outs.ServiceNamespace,
 		AppName:   blockDetails.Block.Name,
 		NewConfigFn: func(ctx context.Context) (*rest.Config, error) {

--- a/gcp/gke/actioner.go
+++ b/gcp/gke/actioner.go
@@ -22,10 +22,9 @@ func NewActioner(ctx context.Context, osWriters logging.OsWriters, source output
 	outs.Deployer.RemoteTokenSourcer = creds.NewTokenSourcer(source, ws.StackId, ws.BlockId, ws.EnvId, types.AutomationPurposePerformAction, "deployer")
 
 	return k8s.Actioner{
-		OsWriters:         osWriters,
-		Namespace:         outs.ServiceNamespace,
-		AppName:           blockDetails.Block.Name,
-		JobDefinitionName: outs.JobDefinitionName,
+		OsWriters: osWriters,
+		Namespace: outs.ServiceNamespace,
+		AppName:   blockDetails.Block.Name,
 		NewConfigFn: func(ctx context.Context) (*rest.Config, error) {
 			return CreateKubeConfig(ctx, outs.ClusterNamespace, outs.Deployer)
 		},

--- a/gcp/gke/actioner.go
+++ b/gcp/gke/actioner.go
@@ -1,0 +1,33 @@
+package gke
+
+import (
+	"context"
+
+	"github.com/nullstone-io/deployment-sdk/gcp/creds"
+	"github.com/nullstone-io/deployment-sdk/k8s"
+	"github.com/nullstone-io/deployment-sdk/logging"
+	"github.com/nullstone-io/deployment-sdk/outputs"
+	"github.com/nullstone-io/deployment-sdk/workspace"
+	"gopkg.in/nullstone-io/go-api-client.v0/types"
+	"k8s.io/client-go/rest"
+)
+
+func NewActioner(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, blockDetails workspace.Details) (workspace.Actioner, error) {
+	outs, err := outputs.Retrieve[Outputs](ctx, source, blockDetails.Workspace, blockDetails.WorkspaceConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	ws := blockDetails.Workspace
+	outs.Deployer.RemoteTokenSourcer = creds.NewTokenSourcer(source, ws.StackId, ws.BlockId, ws.EnvId, types.AutomationPurposePerformAction, "deployer")
+
+	return k8s.Actioner{
+		OsWriters:         osWriters,
+		Namespace:         outs.ServiceNamespace,
+		AppName:           blockDetails.Block.Name,
+		JobDefinitionName: outs.JobDefinitionName,
+		NewConfigFn: func(ctx context.Context) (*rest.Config, error) {
+			return CreateKubeConfig(ctx, outs.ClusterNamespace, outs.Deployer)
+		},
+	}, nil
+}

--- a/gcp/gke/actioner.go
+++ b/gcp/gke/actioner.go
@@ -5,14 +5,13 @@ import (
 
 	"github.com/nullstone-io/deployment-sdk/gcp/creds"
 	"github.com/nullstone-io/deployment-sdk/k8s"
-	"github.com/nullstone-io/deployment-sdk/logging"
 	"github.com/nullstone-io/deployment-sdk/outputs"
 	"github.com/nullstone-io/deployment-sdk/workspace"
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
 	"k8s.io/client-go/rest"
 )
 
-func NewActioner(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, blockDetails workspace.Details) (workspace.Actioner, error) {
+func NewActioner(ctx context.Context, source outputs.RetrieverSource, blockDetails workspace.Details) (workspace.Actioner, error) {
 	outs, err := outputs.Retrieve[Outputs](ctx, source, blockDetails.Workspace, blockDetails.WorkspaceConfig)
 	if err != nil {
 		return nil, err
@@ -22,7 +21,6 @@ func NewActioner(ctx context.Context, osWriters logging.OsWriters, source output
 	outs.Deployer.RemoteTokenSourcer = creds.NewTokenSourcer(source, ws.StackId, ws.BlockId, ws.EnvId, types.AutomationPurposePerformAction, "deployer")
 
 	return k8s.Actioner{
-		OsWriters: osWriters,
 		Namespace: outs.ServiceNamespace,
 		AppName:   blockDetails.Block.Name,
 		NewConfigFn: func(ctx context.Context) (*rest.Config, error) {

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	golang.org/x/sync v0.20.0
 	google.golang.org/api v0.276.0
 	google.golang.org/protobuf v1.36.11
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260319201626-61800dcfeda9
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260502151742-4dc62a93d9a3
 	k8s.io/api v0.35.3
 	k8s.io/apimachinery v0.35.3
 	k8s.io/client-go v0.35.3

--- a/go.sum
+++ b/go.sum
@@ -570,8 +570,8 @@ gopkg.in/evanphx/json-patch.v4 v4.13.0 h1:czT3CmqEaQ1aanPc5SdlgQrrEIb8w/wwCvWWnf
 gopkg.in/evanphx/json-patch.v4 v4.13.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260319201626-61800dcfeda9 h1:ON/Bty+Xt3JLF6b4NsONh3RGILpumGQu4rUflyGH8Ww=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260319201626-61800dcfeda9/go.mod h1:6EH2Rk2Scf4FkoPkYr8XsgBX+FVQO2zseFxryatrG0Y=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260502151742-4dc62a93d9a3 h1:hCLSncRYCcBWV2yXazvrHNgrSRACexjXJqliipiAJzI=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20260502151742-4dc62a93d9a3/go.mod h1:6EH2Rk2Scf4FkoPkYr8XsgBX+FVQO2zseFxryatrG0Y=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/k8s/actioner.go
+++ b/k8s/actioner.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nullstone-io/deployment-sdk/k8s/logs"
 	"github.com/nullstone-io/deployment-sdk/logging"
 	"github.com/nullstone-io/deployment-sdk/workspace"
+	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -30,7 +31,7 @@ type RestartDeploymentResult struct {
 }
 
 type RerunJobInput struct {
-	JobDefinitionName string `json:"jobDefinitionName,omitempty"`
+	JobName string `json:"jobName"`
 }
 
 type RerunJobResult struct {
@@ -47,11 +48,10 @@ type KillPodResult struct {
 }
 
 type Actioner struct {
-	OsWriters         logging.OsWriters
-	Namespace         string
-	AppName           string
-	JobDefinitionName string
-	NewConfigFn       logs.NewConfiger
+	OsWriters   logging.OsWriters
+	Namespace   string
+	AppName     string
+	NewConfigFn logs.NewConfiger
 }
 
 func (a Actioner) PerformAction(ctx context.Context, options workspace.ActionOptions) (*workspace.ActionResult, error) {
@@ -128,7 +128,7 @@ func (a Actioner) restartDeployment(ctx context.Context, input json.RawMessage) 
 	}, nil
 }
 
-// rerunJob creates a new k8s Job from the workspace's job template ConfigMap.
+// rerunJob creates a new k8s Job by copying the spec of an existing job.
 // The new Job is queued by the kube-scheduler; the call returns as soon as creation succeeds.
 func (a Actioner) rerunJob(ctx context.Context, input json.RawMessage) (*workspace.ActionResult, error) {
 	var in RerunJobInput
@@ -137,12 +137,8 @@ func (a Actioner) rerunJob(ctx context.Context, input json.RawMessage) (*workspa
 			return nil, fmt.Errorf("invalid input for %s: %w", ActionRerunJob, err)
 		}
 	}
-	jobDefName := in.JobDefinitionName
-	if jobDefName == "" {
-		jobDefName = a.JobDefinitionName
-	}
-	if jobDefName == "" {
-		return nil, fmt.Errorf("%s requires jobDefinitionName", ActionRerunJob)
+	if in.JobName == "" {
+		return nil, fmt.Errorf("%s requires jobName", ActionRerunJob)
 	}
 
 	client, err := a.newClient(ctx)
@@ -150,16 +146,30 @@ func (a Actioner) rerunJob(ctx context.Context, input json.RawMessage) (*workspa
 		return nil, err
 	}
 
-	jobDef, _, err := GetJobDefinition(ctx, client, a.Namespace, jobDefName)
+	existing, err := client.BatchV1().Jobs(a.Namespace).Get(ctx, in.JobName, metav1.GetOptions{})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error retrieving job %q: %w", in.JobName, err)
 	}
 
-	jobDef.Name = fmt.Sprintf("%s-%d", a.AppName, time.Now().Unix())
-	jobDef.ResourceVersion = ""
-	jobDef.UID = ""
+	// Copy the existing job's spec, clearing the controller-managed fields that
+	// would otherwise conflict with the original job (selector, controller-uid/job-name labels).
+	spec := existing.Spec.DeepCopy()
+	spec.Selector = nil
+	delete(spec.Template.Labels, "controller-uid")
+	delete(spec.Template.Labels, "batch.kubernetes.io/controller-uid")
+	delete(spec.Template.Labels, "job-name")
+	delete(spec.Template.Labels, "batch.kubernetes.io/job-name")
 
-	created, err := client.BatchV1().Jobs(a.Namespace).Create(ctx, jobDef, metav1.CreateOptions{})
+	newJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%d", a.AppName, time.Now().Unix()),
+			Namespace: a.Namespace,
+			Labels:    existing.Labels,
+		},
+		Spec: *spec,
+	}
+
+	created, err := client.BatchV1().Jobs(a.Namespace).Create(ctx, newJob, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("error creating job: %w", err)
 	}
@@ -170,7 +180,7 @@ func (a Actioner) rerunJob(ctx context.Context, input json.RawMessage) (*workspa
 	}
 	return &workspace.ActionResult{
 		Status:  "started",
-		Message: fmt.Sprintf("created job %q from template %q", created.Name, jobDefName),
+		Message: fmt.Sprintf("created job %q from %q", created.Name, in.JobName),
 		Data:    data,
 	}, nil
 }

--- a/k8s/actioner.go
+++ b/k8s/actioner.go
@@ -1,0 +1,213 @@
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/nullstone-io/deployment-sdk/k8s/logs"
+	"github.com/nullstone-io/deployment-sdk/logging"
+	"github.com/nullstone-io/deployment-sdk/workspace"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	ActionRestartDeployment = "restart-deployment"
+	ActionRerunJob          = "rerun-job"
+	ActionKillPod           = "kill-pod"
+)
+
+type RestartDeploymentInput struct {
+	DeploymentName string `json:"deploymentName"`
+}
+
+type RestartDeploymentResult struct {
+	Deployment  string    `json:"deployment"`
+	RestartedAt time.Time `json:"restartedAt"`
+}
+
+type RerunJobInput struct {
+	JobDefinitionName string `json:"jobDefinitionName,omitempty"`
+}
+
+type RerunJobResult struct {
+	Job string `json:"job"`
+}
+
+type KillPodInput struct {
+	PodName            string `json:"podName"`
+	GracePeriodSeconds *int64 `json:"gracePeriodSeconds,omitempty"`
+}
+
+type KillPodResult struct {
+	Pod string `json:"pod"`
+}
+
+type Actioner struct {
+	OsWriters         logging.OsWriters
+	Namespace         string
+	AppName           string
+	JobDefinitionName string
+	NewConfigFn       logs.NewConfiger
+}
+
+func (a Actioner) PerformAction(ctx context.Context, options workspace.ActionOptions) (*workspace.ActionResult, error) {
+	switch options.Action {
+	case ActionRestartDeployment:
+		return a.restartDeployment(ctx, options.Input)
+	case ActionRerunJob:
+		return a.rerunJob(ctx, options.Input)
+	case ActionKillPod:
+		return a.killPod(ctx, options.Input)
+	default:
+		return nil, workspace.ActionNotSupportedError{
+			InnerErr: fmt.Errorf("unknown k8s action %q", options.Action),
+		}
+	}
+}
+
+func (a Actioner) newClient(ctx context.Context) (*kubernetes.Clientset, error) {
+	cfg, err := a.NewConfigFn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error creating kubernetes config: %w", err)
+	}
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("error creating kube client: %w", err)
+	}
+	return client, nil
+}
+
+// restartDeployment patches the deployment's pod template with a kubectl.kubernetes.io/restartedAt
+// annotation, matching the behavior of `kubectl rollout restart deployment/<name>`.
+func (a Actioner) restartDeployment(ctx context.Context, input json.RawMessage) (*workspace.ActionResult, error) {
+	var in RestartDeploymentInput
+	if len(input) > 0 {
+		if err := json.Unmarshal(input, &in); err != nil {
+			return nil, fmt.Errorf("invalid input for %s: %w", ActionRestartDeployment, err)
+		}
+	}
+	if in.DeploymentName == "" {
+		return nil, fmt.Errorf("%s requires deploymentName", ActionRestartDeployment)
+	}
+
+	client, err := a.newClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC()
+	patch := fmt.Sprintf(
+		`{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":%q}}}}}`,
+		now.Format(time.RFC3339),
+	)
+	if _, err := client.AppsV1().Deployments(a.Namespace).Patch(
+		ctx,
+		in.DeploymentName,
+		apitypes.StrategicMergePatchType,
+		[]byte(patch),
+		metav1.PatchOptions{},
+	); err != nil {
+		return nil, fmt.Errorf("error patching deployment %q: %w", in.DeploymentName, err)
+	}
+
+	data, err := json.Marshal(RestartDeploymentResult{
+		Deployment:  in.DeploymentName,
+		RestartedAt: now,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &workspace.ActionResult{
+		Status:  "completed",
+		Message: fmt.Sprintf("restarted deployment %q", in.DeploymentName),
+		Data:    data,
+	}, nil
+}
+
+// rerunJob creates a new k8s Job from the workspace's job template ConfigMap.
+// The new Job is queued by the kube-scheduler; the call returns as soon as creation succeeds.
+func (a Actioner) rerunJob(ctx context.Context, input json.RawMessage) (*workspace.ActionResult, error) {
+	var in RerunJobInput
+	if len(input) > 0 {
+		if err := json.Unmarshal(input, &in); err != nil {
+			return nil, fmt.Errorf("invalid input for %s: %w", ActionRerunJob, err)
+		}
+	}
+	jobDefName := in.JobDefinitionName
+	if jobDefName == "" {
+		jobDefName = a.JobDefinitionName
+	}
+	if jobDefName == "" {
+		return nil, fmt.Errorf("%s requires jobDefinitionName", ActionRerunJob)
+	}
+
+	client, err := a.newClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	jobDef, _, err := GetJobDefinition(ctx, client, a.Namespace, jobDefName)
+	if err != nil {
+		return nil, err
+	}
+
+	jobDef.Name = fmt.Sprintf("%s-%d", a.AppName, time.Now().Unix())
+	jobDef.ResourceVersion = ""
+	jobDef.UID = ""
+
+	created, err := client.BatchV1().Jobs(a.Namespace).Create(ctx, jobDef, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error creating job: %w", err)
+	}
+
+	data, err := json.Marshal(RerunJobResult{Job: created.Name})
+	if err != nil {
+		return nil, err
+	}
+	return &workspace.ActionResult{
+		Status:  "started",
+		Message: fmt.Sprintf("created job %q from template %q", created.Name, jobDefName),
+		Data:    data,
+	}, nil
+}
+
+// killPod deletes a pod by name in the workspace's namespace.
+// The replica set or job controller will reconcile a replacement.
+func (a Actioner) killPod(ctx context.Context, input json.RawMessage) (*workspace.ActionResult, error) {
+	var in KillPodInput
+	if len(input) > 0 {
+		if err := json.Unmarshal(input, &in); err != nil {
+			return nil, fmt.Errorf("invalid input for %s: %w", ActionKillPod, err)
+		}
+	}
+	if in.PodName == "" {
+		return nil, fmt.Errorf("%s requires podName", ActionKillPod)
+	}
+
+	client, err := a.newClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	delOpts := metav1.DeleteOptions{}
+	if in.GracePeriodSeconds != nil {
+		delOpts.GracePeriodSeconds = in.GracePeriodSeconds
+	}
+	if err := client.CoreV1().Pods(a.Namespace).Delete(ctx, in.PodName, delOpts); err != nil {
+		return nil, fmt.Errorf("error deleting pod %q: %w", in.PodName, err)
+	}
+
+	data, err := json.Marshal(KillPodResult{Pod: in.PodName})
+	if err != nil {
+		return nil, err
+	}
+	return &workspace.ActionResult{
+		Status:  "completed",
+		Message: fmt.Sprintf("deleted pod %q", in.PodName),
+		Data:    data,
+	}, nil
+}

--- a/k8s/actioner.go
+++ b/k8s/actioner.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/nullstone-io/deployment-sdk/k8s/logs"
-	"github.com/nullstone-io/deployment-sdk/logging"
 	"github.com/nullstone-io/deployment-sdk/workspace"
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,7 +47,6 @@ type KillPodResult struct {
 }
 
 type Actioner struct {
-	OsWriters   logging.OsWriters
 	Namespace   string
 	AppName     string
 	NewConfigFn logs.NewConfiger

--- a/workspace/actioner.go
+++ b/workspace/actioner.go
@@ -1,0 +1,50 @@
+package workspace
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+type Actioner interface {
+	PerformAction(ctx context.Context, options ActionOptions) (*ActionResult, error)
+}
+
+type ActionOptions struct {
+	// Action identifies the operation to perform (e.g. "restart-deployment", "rerun-job", "kill-pod").
+	// Each Actioner implementation defines the set of actions it supports.
+	Action string
+
+	// Input is the action-specific request payload.
+	// Each implementation unmarshals this into its own typed struct.
+	Input json.RawMessage
+}
+
+type ActionResult struct {
+	Status  string          `json:"status"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+func IsActionNotSupported(err error) (ActionNotSupportedError, bool) {
+	var anse ActionNotSupportedError
+	if errors.As(err, &anse) {
+		return anse, true
+	}
+	return anse, false
+}
+
+var _ error = ActionNotSupportedError{}
+
+type ActionNotSupportedError struct {
+	InnerErr error
+}
+
+func (e ActionNotSupportedError) Error() string {
+	return fmt.Sprintf("action not supported: %s", e.InnerErr)
+}
+
+func (e ActionNotSupportedError) Unwrap() error {
+	return e.InnerErr
+}

--- a/workspace/actioners.go
+++ b/workspace/actioners.go
@@ -1,0 +1,26 @@
+package workspace
+
+import (
+	"context"
+
+	"github.com/nullstone-io/deployment-sdk/contract"
+	"github.com/nullstone-io/deployment-sdk/logging"
+	"github.com/nullstone-io/deployment-sdk/outputs"
+	"gopkg.in/nullstone-io/go-api-client.v0/types"
+)
+
+type NewActionerFunc func(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, blockDetails Details) (Actioner, error)
+
+type Actioners map[types.ModuleContractName]NewActionerFunc
+
+func (s Actioners) FindActioner(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, blockDetails Details) (Actioner, error) {
+	fn := contract.FindInRegistrarByModule(s, blockDetails.Module)
+	if fn == nil || *fn == nil {
+		return nil, nil
+	}
+	a, err := (*fn)(ctx, osWriters, source, blockDetails)
+	if err != nil {
+		return nil, ActionNotSupportedError{InnerErr: err}
+	}
+	return a, nil
+}

--- a/workspace/actioners.go
+++ b/workspace/actioners.go
@@ -4,21 +4,20 @@ import (
 	"context"
 
 	"github.com/nullstone-io/deployment-sdk/contract"
-	"github.com/nullstone-io/deployment-sdk/logging"
 	"github.com/nullstone-io/deployment-sdk/outputs"
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
 )
 
-type NewActionerFunc func(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, blockDetails Details) (Actioner, error)
+type NewActionerFunc func(ctx context.Context, source outputs.RetrieverSource, blockDetails Details) (Actioner, error)
 
 type Actioners map[types.ModuleContractName]NewActionerFunc
 
-func (s Actioners) FindActioner(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, blockDetails Details) (Actioner, error) {
+func (s Actioners) FindActioner(ctx context.Context, source outputs.RetrieverSource, blockDetails Details) (Actioner, error) {
 	fn := contract.FindInRegistrarByModule(s, blockDetails.Module)
 	if fn == nil || *fn == nil {
 		return nil, nil
 	}
-	a, err := (*fn)(ctx, osWriters, source, blockDetails)
+	a, err := (*fn)(ctx, source, blockDetails)
 	if err != nil {
 		return nil, ActionNotSupportedError{InnerErr: err}
 	}

--- a/workspace/all/actioners.go
+++ b/workspace/all/actioners.go
@@ -1,0 +1,18 @@
+package all
+
+import (
+	aws_eks_provider "github.com/nullstone-io/deployment-sdk/app/container/aws-eks"
+	gcp_gke_service "github.com/nullstone-io/deployment-sdk/app/container/gcp-gke-service"
+	"github.com/nullstone-io/deployment-sdk/aws/eks"
+	"github.com/nullstone-io/deployment-sdk/gcp/gke"
+	"github.com/nullstone-io/deployment-sdk/workspace"
+)
+
+var (
+	// Actioners is a factory for creating a new Actioner from a workspace
+	// If the factory method returns an error, it is wrapped with ActionNotSupportedError
+	Actioners = workspace.Actioners{
+		aws_eks_provider.ModuleContractName: eks.NewActioner,
+		gcp_gke_service.ModuleContractName:  gke.NewActioner,
+	}
+)


### PR DESCRIPTION
This creates a new generic provider `Actioner` that allows user to perform specific operations on their workspaces.
This initial implementation comes with support for GKE and EKS actioner with the following commands: 
```
	ActionRestartDeployment = "restart-deployment"
	ActionRerunJob          = "rerun-job"
	ActionKillPod           = "kill-pod"
```