### PR TITLE
Fix/stderr pusher logs

### DIFF
--- a/aws/beanstalk/pusher.go
+++ b/aws/beanstalk/pusher.go
@@ -45,12 +45,12 @@ func (p Pusher) Push(ctx context.Context, source, version string) error {
 		return err
 	}
 
-	stdout, _ := p.OsWriters.Stdout(), p.OsWriters.Stderr()
-	fmt.Fprintf(stdout, "Creating application version %q...\n", version)
+	stderr := p.OsWriters.Stderr()
+	fmt.Fprintf(stderr, "Creating application version %q...\n", version)
 	if _, err := CreateAppVersion(ctx, p.Infra, version); err != nil {
 		return fmt.Errorf("error creating application version: %w", err)
 	}
-	fmt.Fprintf(stdout, "Created application version %q\n", version)
+	fmt.Fprintf(stderr, "Created application version %q\n", version)
 
 	return nil
 }

--- a/aws/ecr/pusher.go
+++ b/aws/ecr/pusher.go
@@ -51,7 +51,7 @@ type Pusher struct {
 }
 
 func (p Pusher) Print() {
-	_, stderr := p.OsWriters.Stdout(), p.OsWriters.Stderr()
+	stderr := p.OsWriters.Stderr()
 	colorstring.Fprintln(stderr, "[bold]Retrieved ECR outputs")
 	fmt.Fprintf(stderr, "\tregion:         %s\n", p.Infra.Region)
 	fmt.Fprintf(stderr, "\timage_repo_url: %s\n", p.Infra.ImageRepoUrl)
@@ -59,7 +59,7 @@ func (p Pusher) Print() {
 }
 
 func (p Pusher) Push(ctx context.Context, source, version string) error {
-	stdout, _ := p.OsWriters.Stdout(), p.OsWriters.Stderr()
+	stderr := p.OsWriters.Stderr()
 	p.Print()
 
 	sourceUrl := docker.ParseImageUrl(source)
@@ -70,27 +70,27 @@ func (p Pusher) Push(ctx context.Context, source, version string) error {
 		return err
 	}
 
-	fmt.Fprintln(stdout)
-	fmt.Fprintln(stdout, "Authenticating with ECR...")
+	fmt.Fprintln(stderr)
+	fmt.Fprintln(stderr, "Authenticating with ECR...")
 	targetAuth, err := p.getEcrLoginAuth(ctx)
 	if err != nil {
 		return fmt.Errorf("error retrieving image registry credentials: %w", err)
 	}
-	fmt.Fprintln(stdout, "Authenticated")
+	fmt.Fprintln(stderr, "Authenticated")
 
 	dockerCli, err := docker.DiscoverDockerCli(p.OsWriters)
 	if err != nil {
 		return fmt.Errorf("error creating docker client: %w", err)
 	}
 
-	fmt.Fprintf(stdout, "Retagging source image %s => %s\n", sourceUrl, targetUrl)
+	fmt.Fprintf(stderr, "Retagging source image %s => %s\n", sourceUrl, targetUrl)
 	opts := client.ImageTagOptions{Source: sourceUrl.String(), Target: targetUrl.String()}
 	if _, err := dockerCli.Client().ImageTag(ctx, opts); err != nil {
 		return fmt.Errorf("error retagging image: %w", err)
 	}
 
-	fmt.Fprintln(stdout)
-	colorstring.Fprintf(stdout, "[bold]Pushing docker image to %s\n", targetUrl)
+	fmt.Fprintln(stderr)
+	colorstring.Fprintf(stderr, "[bold]Pushing docker image to %s\n", targetUrl)
 	if err := docker.PushImage(ctx, dockerCli, targetUrl, targetAuth); err != nil {
 		return fmt.Errorf("error pushing image: %w", err)
 	}
@@ -99,7 +99,7 @@ func (p Pusher) Push(ctx context.Context, source, version string) error {
 }
 
 func (p Pusher) Pull(ctx context.Context, version string) error {
-	stdout, _ := p.OsWriters.Stdout(), p.OsWriters.Stderr()
+	stderr := p.OsWriters.Stderr()
 	p.Print()
 
 	sourceUrl := p.Infra.ImageRepoUrl
@@ -108,21 +108,21 @@ func (p Pusher) Pull(ctx context.Context, version string) error {
 		return err
 	}
 
-	fmt.Fprintln(stdout)
-	fmt.Fprintln(stdout, "Authenticating with ECR...")
+	fmt.Fprintln(stderr)
+	fmt.Fprintln(stderr, "Authenticating with ECR...")
 	sourceAuth, err := p.getEcrLoginAuth(ctx)
 	if err != nil {
 		return fmt.Errorf("error retrieving image registry credentials: %w", err)
 	}
-	fmt.Fprintln(stdout, "Authenticated")
+	fmt.Fprintln(stderr, "Authenticated")
 
 	dockerCli, err := docker.DiscoverDockerCli(p.OsWriters)
 	if err != nil {
 		return fmt.Errorf("error creating docker client: %w", err)
 	}
 
-	fmt.Fprintln(stdout)
-	colorstring.Fprintf(stdout, "[bold]Pulling docker image %s\n", sourceUrl)
+	fmt.Fprintln(stderr)
+	colorstring.Fprintf(stderr, "[bold]Pulling docker image %s\n", sourceUrl)
 	if err := docker.PullImage(ctx, dockerCli, sourceUrl, sourceAuth); err != nil {
 		return fmt.Errorf("error pulling image: %w", err)
 	}

--- a/aws/ecr/pusher.go
+++ b/aws/ecr/pusher.go
@@ -51,11 +51,11 @@ type Pusher struct {
 }
 
 func (p Pusher) Print() {
-	stdout, _ := p.OsWriters.Stdout(), p.OsWriters.Stderr()
-	colorstring.Fprintln(stdout, "[bold]Retrieved ECR outputs")
-	fmt.Fprintf(stdout, "	region:         %s\n", p.Infra.Region)
-	fmt.Fprintf(stdout, "	image_repo_url: %s\n", p.Infra.ImageRepoUrl)
-	fmt.Fprintf(stdout, "	image_pusher:   %s\n", p.Infra.ImagePusher.Name)
+	_, stderr := p.OsWriters.Stdout(), p.OsWriters.Stderr()
+	colorstring.Fprintln(stderr, "[bold]Retrieved ECR outputs")
+	fmt.Fprintf(stderr, "\tregion:         %s\n", p.Infra.Region)
+	fmt.Fprintf(stderr, "\timage_repo_url: %s\n", p.Infra.ImageRepoUrl)
+	fmt.Fprintf(stderr, "\timage_pusher:   %s\n", p.Infra.ImagePusher.Name)
 }
 
 func (p Pusher) Push(ctx context.Context, source, version string) error {

--- a/aws/s3/dir_pusher.go
+++ b/aws/s3/dir_pusher.go
@@ -34,7 +34,7 @@ type DirPusher struct {
 }
 
 func (p DirPusher) Push(ctx context.Context, source, version string) error {
-	stdout, _ := p.OsWriters.Stdout(), p.OsWriters.Stderr()
+	stderr := p.OsWriters.Stderr()
 
 	if source == "" {
 		return fmt.Errorf("no source specified, source artifact (directory or archive) is required to push")
@@ -48,7 +48,7 @@ func (p DirPusher) Push(ctx context.Context, source, version string) error {
 		return fmt.Errorf("error scanning source: %w", err)
 	}
 
-	fmt.Fprintf(stdout, "Uploading %s to s3 bucket %s...\n", source, p.Infra.ArtifactsBucketName)
+	fmt.Fprintf(stderr, "Uploading %s to s3 bucket %s...\n", source, p.Infra.ArtifactsBucketName)
 	if err := UploadDirArtifact(ctx, p.Infra, source, filepaths, version); err != nil {
 		return fmt.Errorf("error uploading artifact: %w", err)
 	}
@@ -57,7 +57,7 @@ func (p DirPusher) Push(ctx context.Context, source, version string) error {
 }
 
 func (p DirPusher) Pull(ctx context.Context, version string) error {
-	stdout, _ := p.OsWriters.Stdout(), p.OsWriters.Stderr()
+	stderr := p.OsWriters.Stderr()
 
 	if version == "" {
 		return fmt.Errorf("no version specified, version is required to pull")
@@ -65,12 +65,12 @@ func (p DirPusher) Pull(ctx context.Context, version string) error {
 
 	localDir := fmt.Sprintf("./%s-%s-%s", p.AppDetails.App.Name, p.AppDetails.Env.Name, version)
 
-	fmt.Fprintf(stdout, "Downloading from s3 bucket %s to %s...\n", p.Infra.ArtifactsBucketName, localDir)
+	fmt.Fprintf(stderr, "Downloading from s3 bucket %s to %s...\n", p.Infra.ArtifactsBucketName, localDir)
 	if err := DownloadDirArtifact(ctx, p.Infra, localDir, version); err != nil {
 		return fmt.Errorf("error downloading artifact: %w", err)
 	}
 
-	fmt.Fprintln(stdout, "Download complete")
+	fmt.Fprintln(stderr, "Download complete")
 	return nil
 }
 

--- a/aws/s3/zip_pusher.go
+++ b/aws/s3/zip_pusher.go
@@ -31,7 +31,7 @@ type ZipPusher struct {
 }
 
 func (p ZipPusher) Push(ctx context.Context, source, version string) error {
-	stdout, _ := p.OsWriters.Stdout(), p.OsWriters.Stderr()
+	stderr := p.OsWriters.Stderr()
 
 	if source == "" {
 		return fmt.Errorf("--source is required to upload artifact")
@@ -48,17 +48,17 @@ func (p ZipPusher) Push(ctx context.Context, source, version string) error {
 	}
 	defer file.Close()
 
-	fmt.Fprintf(stdout, "Uploading %s to artifacts bucket\n", p.Infra.ArtifactsKey(version))
+	fmt.Fprintf(stderr, "Uploading %s to artifacts bucket\n", p.Infra.ArtifactsKey(version))
 	if err := UploadZipArtifact(ctx, p.Infra, file, version); err != nil {
 		return fmt.Errorf("error uploading artifact: %w", err)
 	}
 
-	fmt.Fprintln(stdout, "Upload complete")
+	fmt.Fprintln(stderr, "Upload complete")
 	return nil
 }
 
 func (p ZipPusher) Pull(ctx context.Context, version string) error {
-	stdout, _ := p.OsWriters.Stdout(), p.OsWriters.Stderr()
+	stderr := p.OsWriters.Stderr()
 
 	if version == "" {
 		return fmt.Errorf("no version specified, version is required to pull")
@@ -66,12 +66,12 @@ func (p ZipPusher) Pull(ctx context.Context, version string) error {
 
 	localPath := fmt.Sprintf("./%s-%s-%s.zip", p.AppDetails.App.Name, p.AppDetails.Env.Name, version)
 
-	fmt.Fprintf(stdout, "Downloading %s from artifacts bucket\n", p.Infra.ArtifactsKey(version))
+	fmt.Fprintf(stderr, "Downloading %s from artifacts bucket\n", p.Infra.ArtifactsKey(version))
 	if err := DownloadZipArtifact(ctx, p.Infra, localPath, version); err != nil {
 		return fmt.Errorf("error downloading artifact: %w", err)
 	}
 
-	fmt.Fprintln(stdout, "Download complete")
+	fmt.Fprintln(stderr, "Download complete")
 	return nil
 }
 

--- a/azure/acr/pusher.go
+++ b/azure/acr/pusher.go
@@ -53,7 +53,7 @@ type Pusher struct {
 }
 
 func (p Pusher) Print() {
-	_, stderr := p.OsWriters.Stdout(), p.OsWriters.Stderr()
+	stderr := p.OsWriters.Stderr()
 	colorstring.Fprintln(stderr, "[bold]Retrieved ACR outputs")
 	fmt.Fprintf(stderr, "\tregistry_url:   %s\n", p.Infra.RegistryUrl)
 	fmt.Fprintf(stderr, "\timage_repo_url: %s\n", p.Infra.ImageRepoUrl)
@@ -61,7 +61,7 @@ func (p Pusher) Print() {
 }
 
 func (p Pusher) Push(ctx context.Context, source, version string) error {
-	stdout, _ := p.OsWriters.Stdout(), p.OsWriters.Stderr()
+	stderr := p.OsWriters.Stderr()
 	p.Print()
 
 	sourceUrl := docker.ParseImageUrl(source)
@@ -72,27 +72,27 @@ func (p Pusher) Push(ctx context.Context, source, version string) error {
 		return err
 	}
 
-	fmt.Fprintln(stdout)
-	fmt.Fprintln(stdout, "Authenticating with ACR...")
+	fmt.Fprintln(stderr)
+	fmt.Fprintln(stderr, "Authenticating with ACR...")
 	targetAuth, err := p.getAcrLoginAuth(ctx)
 	if err != nil {
 		return fmt.Errorf("error retrieving ACR credentials: %w", err)
 	}
-	fmt.Fprintln(stdout, "Authenticated")
+	fmt.Fprintln(stderr, "Authenticated")
 
 	dockerCli, err := docker.DiscoverDockerCli(p.OsWriters)
 	if err != nil {
 		return fmt.Errorf("error creating docker client: %w", err)
 	}
 
-	fmt.Fprintf(stdout, "Retagging source image %s => %s\n", sourceUrl, targetUrl)
+	fmt.Fprintf(stderr, "Retagging source image %s => %s\n", sourceUrl, targetUrl)
 	opts := client.ImageTagOptions{Source: sourceUrl.String(), Target: targetUrl.String()}
 	if _, err := dockerCli.Client().ImageTag(ctx, opts); err != nil {
 		return fmt.Errorf("error retagging image: %w", err)
 	}
 
-	fmt.Fprintln(stdout)
-	colorstring.Fprintf(stdout, "[bold]Pushing docker image to %s\n", targetUrl)
+	fmt.Fprintln(stderr)
+	colorstring.Fprintf(stderr, "[bold]Pushing docker image to %s\n", targetUrl)
 	if err := docker.PushImage(ctx, dockerCli, targetUrl, targetAuth); err != nil {
 		return fmt.Errorf("error pushing image: %w", err)
 	}
@@ -101,7 +101,7 @@ func (p Pusher) Push(ctx context.Context, source, version string) error {
 }
 
 func (p Pusher) Pull(ctx context.Context, version string) error {
-	stdout, _ := p.OsWriters.Stdout(), p.OsWriters.Stderr()
+	stderr := p.OsWriters.Stderr()
 	p.Print()
 
 	sourceUrl := p.Infra.ImageRepoUrl
@@ -110,21 +110,21 @@ func (p Pusher) Pull(ctx context.Context, version string) error {
 		return err
 	}
 
-	fmt.Fprintln(stdout)
-	fmt.Fprintln(stdout, "Authenticating with ACR...")
+	fmt.Fprintln(stderr)
+	fmt.Fprintln(stderr, "Authenticating with ACR...")
 	sourceAuth, err := p.getAcrLoginAuth(ctx)
 	if err != nil {
 		return fmt.Errorf("error retrieving ACR credentials: %w", err)
 	}
-	fmt.Fprintln(stdout, "Authenticated")
+	fmt.Fprintln(stderr, "Authenticated")
 
 	dockerCli, err := docker.DiscoverDockerCli(p.OsWriters)
 	if err != nil {
 		return fmt.Errorf("error creating docker client: %w", err)
 	}
 
-	fmt.Fprintln(stdout)
-	colorstring.Fprintf(stdout, "[bold]Pulling docker image %s\n", sourceUrl)
+	fmt.Fprintln(stderr)
+	colorstring.Fprintf(stderr, "[bold]Pulling docker image %s\n", sourceUrl)
 	if err := docker.PullImage(ctx, dockerCli, sourceUrl, sourceAuth); err != nil {
 		return fmt.Errorf("error pulling image: %w", err)
 	}

--- a/azure/acr/pusher.go
+++ b/azure/acr/pusher.go
@@ -53,11 +53,11 @@ type Pusher struct {
 }
 
 func (p Pusher) Print() {
-	stdout, _ := p.OsWriters.Stdout(), p.OsWriters.Stderr()
-	colorstring.Fprintln(stdout, "[bold]Retrieved ACR outputs")
-	fmt.Fprintf(stdout, "\tregistry_url:   %s\n", p.Infra.RegistryUrl)
-	fmt.Fprintf(stdout, "\timage_repo_url: %s\n", p.Infra.ImageRepoUrl)
-	fmt.Fprintf(stdout, "\timage_pusher:   %s/%s\n", p.Infra.ImagePusher.TenantId, p.Infra.ImagePusher.ClientId)
+	_, stderr := p.OsWriters.Stdout(), p.OsWriters.Stderr()
+	colorstring.Fprintln(stderr, "[bold]Retrieved ACR outputs")
+	fmt.Fprintf(stderr, "\tregistry_url:   %s\n", p.Infra.RegistryUrl)
+	fmt.Fprintf(stderr, "\timage_repo_url: %s\n", p.Infra.ImageRepoUrl)
+	fmt.Fprintf(stderr, "\timage_pusher:   %s/%s\n", p.Infra.ImagePusher.TenantId, p.Infra.ImagePusher.ClientId)
 }
 
 func (p Pusher) Push(ctx context.Context, source, version string) error {

--- a/azure/blob/dir_pusher.go
+++ b/azure/blob/dir_pusher.go
@@ -39,7 +39,7 @@ type DirPusher struct {
 }
 
 func (p DirPusher) Push(ctx context.Context, source, version string) error {
-	stdout, _ := p.OsWriters.Stdout(), p.OsWriters.Stderr()
+	stderr := p.OsWriters.Stderr()
 
 	if source == "" {
 		return fmt.Errorf("no source specified, source artifact (directory or archive) is required to push")
@@ -62,7 +62,7 @@ func (p DirPusher) Push(ctx context.Context, source, version string) error {
 	objDir = strings.TrimPrefix(objDir, "/")
 	logger := log.New(os.Stderr, "", 0)
 
-	fmt.Fprintf(stdout, "Uploading %s to Azure Blob Storage %s/%s...\n", source, p.Infra.StorageAccount, p.Infra.ContainerName)
+	fmt.Fprintf(stderr, "Uploading %s to Azure Blob Storage %s/%s...\n", source, p.Infra.StorageAccount, p.Infra.ContainerName)
 	for _, fp := range filepaths {
 		relPath, err := filepath.Rel(source, fp)
 		if err != nil {
@@ -89,7 +89,7 @@ func (p DirPusher) Push(ctx context.Context, source, version string) error {
 }
 
 func (p DirPusher) Pull(ctx context.Context, version string) error {
-	stdout, _ := p.OsWriters.Stdout(), p.OsWriters.Stderr()
+	stderr := p.OsWriters.Stderr()
 
 	if version == "" {
 		return fmt.Errorf("no version specified, version is required to pull")
@@ -104,7 +104,7 @@ func (p DirPusher) Pull(ctx context.Context, version string) error {
 	prefix = strings.TrimPrefix(prefix, "/")
 	localDir := fmt.Sprintf("./%s-%s-%s", p.AppDetails.App.Name, p.AppDetails.Env.Name, version)
 
-	fmt.Fprintf(stdout, "Downloading from Azure Blob Storage to %s...\n", localDir)
+	fmt.Fprintf(stderr, "Downloading from Azure Blob Storage to %s...\n", localDir)
 	pager := client.NewListBlobsFlatPager(p.Infra.ContainerName, &azblob.ListBlobsFlatOptions{
 		Prefix: &prefix,
 	})
@@ -143,7 +143,7 @@ func (p DirPusher) Pull(ctx context.Context, version string) error {
 		}
 	}
 
-	fmt.Fprintln(stdout, "Download complete")
+	fmt.Fprintln(stderr, "Download complete")
 	return nil
 }
 

--- a/azure/blob/zip_pusher.go
+++ b/azure/blob/zip_pusher.go
@@ -36,7 +36,7 @@ type ZipPusher struct {
 }
 
 func (p ZipPusher) Push(ctx context.Context, source, version string) error {
-	stdout, _ := p.OsWriters.Stdout(), p.OsWriters.Stderr()
+	stderr := p.OsWriters.Stderr()
 
 	if source == "" {
 		return fmt.Errorf("no source specified, source artifact (zip file) is required to push")
@@ -57,7 +57,7 @@ func (p ZipPusher) Push(ctx context.Context, source, version string) error {
 	objectKey := p.Infra.ArtifactsKey(version)
 	objectKey = strings.TrimPrefix(objectKey, "/")
 
-	fmt.Fprintf(stdout, "Uploading %s to Azure Blob Storage...\n", source)
+	fmt.Fprintf(stderr, "Uploading %s to Azure Blob Storage...\n", source)
 	file, err := os.Open(absSource)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -72,12 +72,12 @@ func (p ZipPusher) Push(ctx context.Context, source, version string) error {
 		return fmt.Errorf("error uploading artifact: %w", err)
 	}
 
-	fmt.Fprintln(stdout, "Upload complete")
+	fmt.Fprintln(stderr, "Upload complete")
 	return nil
 }
 
 func (p ZipPusher) Pull(ctx context.Context, version string) error {
-	stdout, _ := p.OsWriters.Stdout(), p.OsWriters.Stderr()
+	stderr := p.OsWriters.Stderr()
 
 	if version == "" {
 		return fmt.Errorf("no version specified, version is required to pull")
@@ -92,7 +92,7 @@ func (p ZipPusher) Pull(ctx context.Context, version string) error {
 	objectKey = strings.TrimPrefix(objectKey, "/")
 	localPath := fmt.Sprintf("./%s-%s-%s.zip", p.AppDetails.App.Name, p.AppDetails.Env.Name, version)
 
-	fmt.Fprintf(stdout, "Downloading %s from Azure Blob Storage...\n", objectKey)
+	fmt.Fprintf(stderr, "Downloading %s from Azure Blob Storage...\n", objectKey)
 	file, err := os.Create(localPath)
 	if err != nil {
 		return fmt.Errorf("error creating local file: %w", err)
@@ -104,7 +104,7 @@ func (p ZipPusher) Pull(ctx context.Context, version string) error {
 		return fmt.Errorf("error downloading artifact: %w", err)
 	}
 
-	fmt.Fprintln(stdout, "Download complete")
+	fmt.Fprintln(stderr, "Download complete")
 	return nil
 }
 

--- a/docker/pull_image.go
+++ b/docker/pull_image.go
@@ -25,5 +25,5 @@ func PullImage(ctx context.Context, dockerCli *command.DockerCli, sourceUrl Imag
 		return err
 	}
 
-	return jsonmessage.DisplayJSONMessagesToStream(responseBody, dockerCli.Out(), nil)
+	return jsonmessage.DisplayJSONMessagesToStream(responseBody, dockerCli.Err(), nil)
 }

--- a/docker/push_image.go
+++ b/docker/push_image.go
@@ -25,5 +25,5 @@ func PushImage(ctx context.Context, dockerCli *command.DockerCli, targetUrl Imag
 		return err
 	}
 
-	return jsonmessage.DisplayJSONMessagesToStream(responseBody, dockerCli.Out(), nil)
+	return jsonmessage.DisplayJSONMessagesToStream(responseBody, dockerCli.Err(), nil)
 }

--- a/gcp/gar/pusher.go
+++ b/gcp/gar/pusher.go
@@ -49,14 +49,14 @@ type Pusher struct {
 }
 
 func (p Pusher) Print() {
-	_, stderr := p.OsWriters.Stdout(), p.OsWriters.Stderr()
+	stderr := p.OsWriters.Stderr()
 	colorstring.Fprintln(stderr, "[bold]Retrieved GAR or GCR outputs")
 	fmt.Fprintf(stderr, "\timage_repo_url: %s\n", p.Infra.ImageRepoUrl)
 	fmt.Fprintf(stderr, "\timage_pusher:   %s\n", p.Infra.ImagePusher.Email)
 }
 
 func (p Pusher) Push(ctx context.Context, source, version string) error {
-	stdout, _ := p.OsWriters.Stdout(), p.OsWriters.Stderr()
+	stderr := p.OsWriters.Stderr()
 	p.Print()
 
 	sourceUrl := docker.ParseImageUrl(source)
@@ -67,27 +67,27 @@ func (p Pusher) Push(ctx context.Context, source, version string) error {
 		return err
 	}
 
-	fmt.Fprintln(stdout)
-	fmt.Fprintln(stdout, "Authenticating with GAR or GCR...")
+	fmt.Fprintln(stderr)
+	fmt.Fprintln(stderr, "Authenticating with GAR or GCR...")
 	targetAuth, err := p.getGcrLoginAuth(ctx)
 	if err != nil {
 		return fmt.Errorf("error retrieving image registry credentials: %w", err)
 	}
-	fmt.Fprintln(stdout, "Authenticated")
+	fmt.Fprintln(stderr, "Authenticated")
 
 	dockerCli, err := docker.DiscoverDockerCli(p.OsWriters)
 	if err != nil {
 		return fmt.Errorf("error creating docker client: %w", err)
 	}
 
-	fmt.Fprintf(stdout, "Retagging source image %s => %s\n", sourceUrl, targetUrl)
+	fmt.Fprintf(stderr, "Retagging source image %s => %s\n", sourceUrl, targetUrl)
 	opts := client.ImageTagOptions{Source: sourceUrl.String(), Target: targetUrl.String()}
 	if _, err := dockerCli.Client().ImageTag(ctx, opts); err != nil {
 		return fmt.Errorf("error retagging image: %w", err)
 	}
 
-	fmt.Fprintln(stdout)
-	colorstring.Fprintf(stdout, "[bold]Pushing docker image to %s\n", targetUrl)
+	fmt.Fprintln(stderr)
+	colorstring.Fprintf(stderr, "[bold]Pushing docker image to %s\n", targetUrl)
 	if err := docker.PushImage(ctx, dockerCli, targetUrl, targetAuth); err != nil {
 		return fmt.Errorf("error pushing image: %w", err)
 	}
@@ -96,7 +96,7 @@ func (p Pusher) Push(ctx context.Context, source, version string) error {
 }
 
 func (p Pusher) Pull(ctx context.Context, version string) error {
-	stdout, _ := p.OsWriters.Stdout(), p.OsWriters.Stderr()
+	stderr := p.OsWriters.Stderr()
 	p.Print()
 
 	sourceUrl := p.Infra.ImageRepoUrl
@@ -105,21 +105,21 @@ func (p Pusher) Pull(ctx context.Context, version string) error {
 		return err
 	}
 
-	fmt.Fprintln(stdout)
-	fmt.Fprintln(stdout, "Authenticating with GAR or GCR...")
+	fmt.Fprintln(stderr)
+	fmt.Fprintln(stderr, "Authenticating with GAR or GCR...")
 	sourceAuth, err := p.getGcrLoginAuth(ctx)
 	if err != nil {
 		return fmt.Errorf("error retrieving image registry credentials: %w", err)
 	}
-	fmt.Fprintln(stdout, "Authenticated")
+	fmt.Fprintln(stderr, "Authenticated")
 
 	dockerCli, err := docker.DiscoverDockerCli(p.OsWriters)
 	if err != nil {
 		return fmt.Errorf("error creating docker client: %w", err)
 	}
 
-	fmt.Fprintln(stdout)
-	colorstring.Fprintf(stdout, "[bold]Pulling docker image %s\n", sourceUrl)
+	fmt.Fprintln(stderr)
+	colorstring.Fprintf(stderr, "[bold]Pulling docker image %s\n", sourceUrl)
 	if err := docker.PullImage(ctx, dockerCli, sourceUrl, sourceAuth); err != nil {
 		return fmt.Errorf("error pulling image: %w", err)
 	}

--- a/gcp/gar/pusher.go
+++ b/gcp/gar/pusher.go
@@ -49,10 +49,10 @@ type Pusher struct {
 }
 
 func (p Pusher) Print() {
-	stdout, _ := p.OsWriters.Stdout(), p.OsWriters.Stderr()
-	colorstring.Fprintln(stdout, "[bold]Retrieved GAR or GCR outputs")
-	fmt.Fprintf(stdout, "	image_repo_url: %s\n", p.Infra.ImageRepoUrl)
-	fmt.Fprintf(stdout, "	image_pusher:   %s\n", p.Infra.ImagePusher.Email)
+	_, stderr := p.OsWriters.Stdout(), p.OsWriters.Stderr()
+	colorstring.Fprintln(stderr, "[bold]Retrieved GAR or GCR outputs")
+	fmt.Fprintf(stderr, "\timage_repo_url: %s\n", p.Infra.ImageRepoUrl)
+	fmt.Fprintf(stderr, "\timage_pusher:   %s\n", p.Infra.ImagePusher.Email)
 }
 
 func (p Pusher) Push(ctx context.Context, source, version string) error {

--- a/gcp/gcs/dir_pusher.go
+++ b/gcp/gcs/dir_pusher.go
@@ -34,7 +34,7 @@ type DirPusher struct {
 }
 
 func (p DirPusher) Push(ctx context.Context, source, version string) error {
-	stdout, _ := p.OsWriters.Stdout(), p.OsWriters.Stderr()
+	stderr := p.OsWriters.Stderr()
 
 	if source == "" {
 		return fmt.Errorf("no source specified, source artifact (directory or archive) is required to push")
@@ -48,7 +48,7 @@ func (p DirPusher) Push(ctx context.Context, source, version string) error {
 		return fmt.Errorf("error scanning source: %w", err)
 	}
 
-	fmt.Fprintf(stdout, "Uploading %s to GCS bucket %s...\n", source, p.Infra.ArtifactsBucketName)
+	fmt.Fprintf(stderr, "Uploading %s to GCS bucket %s...\n", source, p.Infra.ArtifactsBucketName)
 	if err := UploadDirArtifact(ctx, p.Infra, source, filepaths, version); err != nil {
 		return fmt.Errorf("error uploading artifact: %w", err)
 	}
@@ -57,7 +57,7 @@ func (p DirPusher) Push(ctx context.Context, source, version string) error {
 }
 
 func (p DirPusher) Pull(ctx context.Context, version string) error {
-	stdout, _ := p.OsWriters.Stdout(), p.OsWriters.Stderr()
+	stderr := p.OsWriters.Stderr()
 
 	if version == "" {
 		return fmt.Errorf("no version specified, version is required to pull")
@@ -65,12 +65,12 @@ func (p DirPusher) Pull(ctx context.Context, version string) error {
 
 	localDir := fmt.Sprintf("./%s-%s-%s", p.AppDetails.App.Name, p.AppDetails.Env.Name, version)
 
-	fmt.Fprintf(stdout, "Downloading from GCS bucket %s to %s...\n", p.Infra.ArtifactsBucketName, localDir)
+	fmt.Fprintf(stderr, "Downloading from GCS bucket %s to %s...\n", p.Infra.ArtifactsBucketName, localDir)
 	if err := DownloadDirArtifact(ctx, p.Infra, localDir, version); err != nil {
 		return fmt.Errorf("error downloading artifact: %w", err)
 	}
 
-	fmt.Fprintln(stdout, "Download complete")
+	fmt.Fprintln(stderr, "Download complete")
 	return nil
 }
 

--- a/gcp/gcs/zip_pusher.go
+++ b/gcp/gcs/zip_pusher.go
@@ -35,7 +35,7 @@ type ZipPusher struct {
 }
 
 func (p ZipPusher) Push(ctx context.Context, source, version string) error {
-	stdout, _ := p.OsWriters.Stdout(), p.OsWriters.Stderr()
+	stderr := p.OsWriters.Stderr()
 
 	if source == "" {
 		return fmt.Errorf("no source specified, source artifact (zip file) is required to push")
@@ -48,7 +48,7 @@ func (p ZipPusher) Push(ctx context.Context, source, version string) error {
 		return fmt.Errorf("error finding absolute filepath to --source=%s: %w", source, err)
 	}
 
-	fmt.Fprintf(stdout, "Uploading %s to GCS bucket...\n", source)
+	fmt.Fprintf(stderr, "Uploading %s to GCS bucket...\n", source)
 	if err := UploadZipArtifact(ctx, p.Infra, absSource, version); err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("source file %q does not exist", source)
@@ -56,12 +56,12 @@ func (p ZipPusher) Push(ctx context.Context, source, version string) error {
 		return fmt.Errorf("error uploading artifact: %w", err)
 	}
 
-	fmt.Fprintln(stdout, "Upload complete")
+	fmt.Fprintln(stderr, "Upload complete")
 	return nil
 }
 
 func (p ZipPusher) Pull(ctx context.Context, version string) error {
-	stdout, _ := p.OsWriters.Stdout(), p.OsWriters.Stderr()
+	stderr := p.OsWriters.Stderr()
 
 	if version == "" {
 		return fmt.Errorf("no version specified, version is required to pull")
@@ -69,12 +69,12 @@ func (p ZipPusher) Pull(ctx context.Context, version string) error {
 
 	localPath := fmt.Sprintf("./%s-%s-%s.zip", p.AppDetails.App.Name, p.AppDetails.Env.Name, version)
 
-	fmt.Fprintf(stdout, "Downloading %s from GCS bucket...\n", p.Infra.ArtifactsKey(version))
+	fmt.Fprintf(stderr, "Downloading %s from GCS bucket...\n", p.Infra.ArtifactsKey(version))
 	if err := DownloadZipArtifact(ctx, p.Infra, localPath, version); err != nil {
 		return fmt.Errorf("error downloading artifact: %w", err)
 	}
 
-	fmt.Fprintln(stdout, "Download complete")
+	fmt.Fprintln(stderr, "Download complete")
 	return nil
 }
 


### PR DESCRIPTION
This fixes the pusher implementations so that all logging is reported to stderr and the resulting version is emitted to stdout.
This helps with automation to pull the calculated artifact version.