### PR TITLE
Feat/43/cloudrun statuser

### DIFF
--- a/app/log_streamer.go
+++ b/app/log_streamer.go
@@ -43,6 +43,12 @@ type LogStreamOptions struct {
 	// the same way Task is.
 	Job string
 
+	// Execution scopes the log query to a single Cloud Run job execution.
+	// The value is the execution's short name (e.g. "my-job-slqpw"), which matches
+	// the Cloud Logging label run.googleapis.com/execution_name. Honored by the
+	// Cloud Logging streamer; ignored by other providers.
+	Execution string
+
 	// LogStreamNames is the resolved exact list of CloudWatch log streams to filter on.
 	// Populated by an upstream streamer (e.g. the ECS shim) that translates Task/
 	// Deployment/Job into stream names before delegating to the cloudwatch streamer.

--- a/app/log_streamer.go
+++ b/app/log_streamer.go
@@ -49,6 +49,12 @@ type LogStreamOptions struct {
 	// Cloud Logging streamer; ignored by other providers.
 	Execution string
 
+	// Revision scopes the log query to a single Cloud Run service revision.
+	// The value is the revision name (e.g. "my-service-00001-abc"), which matches
+	// the Cloud Logging label run.googleapis.com/revision_name. Honored by the
+	// Cloud Logging streamer; ignored by other providers.
+	Revision string
+
 	// LogStreamNames is the resolved exact list of CloudWatch log streams to filter on.
 	// Populated by an upstream streamer (e.g. the ECS shim) that translates Task/
 	// Deployment/Job into stream names before delegating to the cloudwatch streamer.

--- a/gcp/cloudlogging/log_streamer.go
+++ b/gcp/cloudlogging/log_streamer.go
@@ -46,12 +46,22 @@ type LogStreamer struct {
 	Infra     Outputs
 }
 
+// executionNameLabel is the Cloud Logging label Cloud Run stamps on every job
+// task log entry, identifying the owning execution by its short name.
+const executionNameLabel = "run.googleapis.com/execution_name"
+
 func (s LogStreamer) Stream(ctx context.Context, options app.LogStreamOptions) error {
 	if options.WatchInterval == time.Duration(0) {
 		options.WatchInterval = DefaultWatchInterval
 	}
 	if options.Emitter == nil {
 		options.Emitter = app.NewWriterLogEmitter(os.Stdout)
+	}
+	// Narrow to a single job execution when requested. %q renders both the label
+	// key and value as quoted strings, producing a valid Cloud Logging clause:
+	//   labels."run.googleapis.com/execution_name"="my-job-slqpw"
+	if options.Execution != "" {
+		options.Selectors = append(options.Selectors, fmt.Sprintf("labels.%q=%q", executionNameLabel, options.Execution))
 	}
 
 	logger := log.New(s.OsWriters.Stderr(), "", 0)

--- a/gcp/cloudlogging/log_streamer.go
+++ b/gcp/cloudlogging/log_streamer.go
@@ -50,6 +50,10 @@ type LogStreamer struct {
 // task log entry, identifying the owning execution by its short name.
 const executionNameLabel = "run.googleapis.com/execution_name"
 
+// revisionNameLabel is the Cloud Logging label Cloud Run stamps on every service
+// log entry, identifying the owning revision by its name.
+const revisionNameLabel = "run.googleapis.com/revision_name"
+
 func (s LogStreamer) Stream(ctx context.Context, options app.LogStreamOptions) error {
 	if options.WatchInterval == time.Duration(0) {
 		options.WatchInterval = DefaultWatchInterval
@@ -62,6 +66,11 @@ func (s LogStreamer) Stream(ctx context.Context, options app.LogStreamOptions) e
 	//   labels."run.googleapis.com/execution_name"="my-job-slqpw"
 	if options.Execution != "" {
 		options.Selectors = append(options.Selectors, fmt.Sprintf("labels.%q=%q", executionNameLabel, options.Execution))
+	}
+	// Narrow to a single service revision when requested, producing:
+	//   labels."run.googleapis.com/revision_name"="my-service-00001-abc"
+	if options.Revision != "" {
+		options.Selectors = append(options.Selectors, fmt.Sprintf("labels.%q=%q", revisionNameLabel, options.Revision))
 	}
 
 	logger := log.New(s.OsWriters.Stderr(), "", 0)

--- a/gcp/cloudrun/actioner.go
+++ b/gcp/cloudrun/actioner.go
@@ -1,0 +1,353 @@
+package cloudrun
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/run/apiv2/runpb"
+	"github.com/nullstone-io/deployment-sdk/gcp/creds"
+	"github.com/nullstone-io/deployment-sdk/outputs"
+	"github.com/nullstone-io/deployment-sdk/workspace"
+	"gopkg.in/nullstone-io/go-api-client.v0/types"
+)
+
+const (
+	ActionRestartRevision = "restart-revision"
+	ActionRouteTraffic    = "route-traffic"
+	ActionCancelExecution = "cancel-execution"
+	ActionRerunJob        = "rerun-job"
+
+	// restartAnnotation is bumped on the revision template to force Cloud Run to
+	// mint a fresh revision on UpdateService even when nothing else changed.
+	restartAnnotation = "nullstone.io/restarted-at"
+)
+
+type RestartRevisionInput struct {
+	// RevisionName is the revision the restart was requested from. Cloud Run
+	// revisions are immutable, so the restart redeploys the service's current
+	// template as a new revision; this value is echoed back for traceability.
+	RevisionName string `json:"revisionName"`
+}
+
+type RestartRevisionResult struct {
+	Service      string    `json:"service"`
+	FromRevision string    `json:"fromRevision,omitempty"`
+	RestartedAt  time.Time `json:"restartedAt"`
+	Operation    string    `json:"operation,omitempty"`
+}
+
+type RouteTrafficInput struct {
+	RevisionName string `json:"revisionName"`
+	Percent      int32  `json:"percent"`
+}
+
+type RouteTrafficResult struct {
+	Service      string `json:"service"`
+	RevisionName string `json:"revisionName"`
+	Percent      int32  `json:"percent"`
+}
+
+type CancelExecutionInput struct {
+	ExecutionId string `json:"executionId"`
+}
+
+type CancelExecutionResult struct {
+	Execution string `json:"execution"`
+}
+
+type RerunJobInput struct {
+	// ExecutionId is the execution the rerun was requested from. It is echoed
+	// back but not used to launch: Cloud Run always runs a fresh execution.
+	ExecutionId string `json:"executionId"`
+	// OnlyFailedTasks is accepted for API parity with other providers, but Cloud
+	// Run Jobs cannot rerun individual task indexes — see rerunJob.
+	OnlyFailedTasks bool `json:"onlyFailedTasks"`
+}
+
+type RerunJobResult struct {
+	Job             string `json:"job"`
+	SourceExecution string `json:"sourceExecution,omitempty"`
+	Operation       string `json:"operation,omitempty"`
+}
+
+func NewActioner(ctx context.Context, source outputs.RetrieverSource, blockDetails workspace.Details) (workspace.Actioner, error) {
+	outs, err := outputs.Retrieve[Outputs](ctx, source, blockDetails.Workspace, blockDetails.WorkspaceConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	ws := blockDetails.Workspace
+	outs.Deployer.RemoteTokenSourcer = creds.NewTokenSourcer(source, ws.StackId, ws.BlockId, ws.EnvId, types.AutomationPurposePerformAction, "deployer")
+
+	return Actioner{
+		Infra:   outs,
+		AppName: blockDetails.Block.Name,
+	}, nil
+}
+
+type Actioner struct {
+	Infra   Outputs
+	AppName string
+}
+
+func (a Actioner) PerformAction(ctx context.Context, options workspace.ActionOptions) (*workspace.ActionResult, error) {
+	switch options.Action {
+	case ActionRestartRevision:
+		return a.restartRevision(ctx, options.Input)
+	case ActionRouteTraffic:
+		return a.routeTraffic(ctx, options.Input)
+	case ActionCancelExecution:
+		return a.cancelExecution(ctx, options.Input)
+	case ActionRerunJob:
+		return a.rerunJob(ctx, options.Input)
+	default:
+		return nil, workspace.ActionNotSupportedError{
+			InnerErr: fmt.Errorf("unknown cloud run action %q", options.Action),
+		}
+	}
+}
+
+// restartRevision forces a new revision of the service from its current
+// template, draining the old instances. Cloud Run revisions are immutable, so
+// there's no in-place restart; this mirrors `kubectl rollout restart`.
+//
+// Traffic routing is left untouched: if the service routes to LATEST, the new
+// revision serves automatically; if traffic is pinned to a specific revision,
+// the new revision is created ready-but-idle and can be promoted with
+// route-traffic.
+func (a Actioner) restartRevision(ctx context.Context, input json.RawMessage) (*workspace.ActionResult, error) {
+	if a.Infra.ServiceName == "" {
+		return nil, fmt.Errorf("%s requires a service workspace", ActionRestartRevision)
+	}
+	var in RestartRevisionInput
+	if len(input) > 0 {
+		if err := json.Unmarshal(input, &in); err != nil {
+			return nil, fmt.Errorf("invalid input for %s: %w", ActionRestartRevision, err)
+		}
+	}
+
+	client, err := NewServicesClient(ctx, a.Infra.Deployer)
+	if err != nil {
+		return nil, fmt.Errorf("error initializing cloud run services client: %w", err)
+	}
+	defer client.Close()
+
+	svc, err := client.GetService(ctx, &runpb.GetServiceRequest{Name: a.Infra.ServiceId})
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving service: %w", err)
+	}
+	tmpl := svc.GetTemplate()
+	if tmpl == nil {
+		return nil, fmt.Errorf("service %q has no template to restart", a.Infra.ServiceName)
+	}
+
+	// Clear the pinned revision name so the server auto-generates a fresh one,
+	// and bump the restart annotation so the template differs from the current
+	// revision (otherwise Cloud Run treats the update as a no-op).
+	tmpl.Revision = ""
+	if tmpl.Annotations == nil {
+		tmpl.Annotations = map[string]string{}
+	}
+	restartedAt := time.Now().UTC()
+	tmpl.Annotations[restartAnnotation] = restartedAt.Format(time.RFC3339Nano)
+
+	op, err := client.UpdateService(ctx, &runpb.UpdateServiceRequest{Service: svc})
+	if err != nil {
+		return nil, fmt.Errorf("error restarting service %q: %w", a.Infra.ServiceName, err)
+	}
+	// Don't block on the new revision becoming ready; that can take a while. The
+	// status view reflects progress on the next poll.
+
+	data, err := json.Marshal(RestartRevisionResult{
+		Service:      a.Infra.ServiceName,
+		FromRevision: in.RevisionName,
+		RestartedAt:  restartedAt,
+		Operation:    op.Name(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &workspace.ActionResult{
+		Status:  "started",
+		Message: fmt.Sprintf("restart triggered for service %q", a.Infra.ServiceName),
+		Data:    data,
+	}, nil
+}
+
+// routeTraffic points `percent` of the service's traffic at revisionName. When
+// percent is less than 100 the remainder is routed to the latest ready revision.
+func (a Actioner) routeTraffic(ctx context.Context, input json.RawMessage) (*workspace.ActionResult, error) {
+	if a.Infra.ServiceName == "" {
+		return nil, fmt.Errorf("%s requires a service workspace", ActionRouteTraffic)
+	}
+	var in RouteTrafficInput
+	if len(input) > 0 {
+		if err := json.Unmarshal(input, &in); err != nil {
+			return nil, fmt.Errorf("invalid input for %s: %w", ActionRouteTraffic, err)
+		}
+	}
+	if in.RevisionName == "" {
+		return nil, fmt.Errorf("%s requires revisionName", ActionRouteTraffic)
+	}
+	if in.Percent <= 0 || in.Percent > 100 {
+		return nil, fmt.Errorf("%s requires percent in 1..100, got %d", ActionRouteTraffic, in.Percent)
+	}
+
+	client, err := NewServicesClient(ctx, a.Infra.Deployer)
+	if err != nil {
+		return nil, fmt.Errorf("error initializing cloud run services client: %w", err)
+	}
+	defer client.Close()
+
+	svc, err := client.GetService(ctx, &runpb.GetServiceRequest{Name: a.Infra.ServiceId})
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving service: %w", err)
+	}
+	svc.Traffic = buildTrafficTargets(in.RevisionName, in.Percent, shortName(svc.GetLatestReadyRevision()))
+
+	op, err := client.UpdateService(ctx, &runpb.UpdateServiceRequest{Service: svc})
+	if err != nil {
+		return nil, fmt.Errorf("error routing traffic to %q: %w", in.RevisionName, err)
+	}
+	if _, err := op.Wait(ctx); err != nil {
+		return nil, fmt.Errorf("error waiting for traffic update: %w", err)
+	}
+
+	data, err := json.Marshal(RouteTrafficResult{
+		Service:      a.Infra.ServiceName,
+		RevisionName: in.RevisionName,
+		Percent:      in.Percent,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &workspace.ActionResult{
+		Status:  "completed",
+		Message: fmt.Sprintf("routed %d%% traffic to %q", in.Percent, in.RevisionName),
+		Data:    data,
+	}, nil
+}
+
+// buildTrafficTargets builds a traffic split that sends `percent` to
+// revisionName. When percent < 100 the remainder goes to the latest ready
+// revision, or to the LATEST allocation when that's unknown or is the same
+// revision.
+func buildTrafficTargets(revisionName string, percent int32, latestReady string) []*runpb.TrafficTarget {
+	targets := []*runpb.TrafficTarget{{
+		Type:     runpb.TrafficTargetAllocationType_TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION,
+		Revision: revisionName,
+		Percent:  percent,
+	}}
+	if percent >= 100 {
+		return targets
+	}
+
+	remainder := 100 - percent
+	if latestReady != "" && latestReady != revisionName {
+		targets = append(targets, &runpb.TrafficTarget{
+			Type:     runpb.TrafficTargetAllocationType_TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION,
+			Revision: latestReady,
+			Percent:  remainder,
+		})
+	} else {
+		targets = append(targets, &runpb.TrafficTarget{
+			Type:    runpb.TrafficTargetAllocationType_TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST,
+			Percent: remainder,
+		})
+	}
+	return targets
+}
+
+// cancelExecution cancels a running job execution. It waits for the cancel to
+// be acknowledged so the caller gets a real confirmation (or the failure).
+func (a Actioner) cancelExecution(ctx context.Context, input json.RawMessage) (*workspace.ActionResult, error) {
+	if a.Infra.JobName == "" {
+		return nil, fmt.Errorf("%s requires a job workspace", ActionCancelExecution)
+	}
+	var in CancelExecutionInput
+	if len(input) > 0 {
+		if err := json.Unmarshal(input, &in); err != nil {
+			return nil, fmt.Errorf("invalid input for %s: %w", ActionCancelExecution, err)
+		}
+	}
+	if in.ExecutionId == "" {
+		return nil, fmt.Errorf("%s requires executionId", ActionCancelExecution)
+	}
+
+	client, err := NewExecutionsClient(ctx, a.Infra.Deployer)
+	if err != nil {
+		return nil, fmt.Errorf("error initializing cloud run executions client: %w", err)
+	}
+	defer client.Close()
+
+	op, err := client.CancelExecution(ctx, &runpb.CancelExecutionRequest{Name: a.executionName(in.ExecutionId)})
+	if err != nil {
+		return nil, fmt.Errorf("error cancelling execution %q: %w", in.ExecutionId, err)
+	}
+	if _, err := op.Wait(ctx); err != nil {
+		return nil, fmt.Errorf("error waiting for execution %q to cancel: %w", in.ExecutionId, err)
+	}
+
+	data, err := json.Marshal(CancelExecutionResult{Execution: in.ExecutionId})
+	if err != nil {
+		return nil, err
+	}
+	return &workspace.ActionResult{
+		Status:  "completed",
+		Message: fmt.Sprintf("cancelled execution %q", in.ExecutionId),
+		Data:    data,
+	}, nil
+}
+
+// rerunJob launches a fresh execution of the job. Cloud Run Jobs has no API to
+// rerun individual task indexes, so OnlyFailedTasks cannot be honored — the
+// whole job is re-executed and the result message says so. (The job's own
+// per-task retry policy handles transient task failures within an execution.)
+func (a Actioner) rerunJob(ctx context.Context, input json.RawMessage) (*workspace.ActionResult, error) {
+	if a.Infra.JobName == "" {
+		return nil, fmt.Errorf("%s requires a job workspace", ActionRerunJob)
+	}
+	var in RerunJobInput
+	if len(input) > 0 {
+		if err := json.Unmarshal(input, &in); err != nil {
+			return nil, fmt.Errorf("invalid input for %s: %w", ActionRerunJob, err)
+		}
+	}
+
+	client, err := NewJobsClient(ctx, a.Infra.Deployer)
+	if err != nil {
+		return nil, fmt.Errorf("error initializing cloud run jobs client: %w", err)
+	}
+	defer client.Close()
+
+	op, err := client.RunJob(ctx, &runpb.RunJobRequest{Name: a.Infra.JobId})
+	if err != nil {
+		return nil, fmt.Errorf("error running job %q: %w", a.Infra.JobName, err)
+	}
+	// Don't wait: the execution runs asynchronously and may take a long time.
+
+	data, err := json.Marshal(RerunJobResult{
+		Job:             a.Infra.JobName,
+		SourceExecution: in.ExecutionId,
+		Operation:       op.Name(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	msg := fmt.Sprintf("started a new execution of job %q", a.Infra.JobName)
+	if in.OnlyFailedTasks {
+		msg = fmt.Sprintf("Cloud Run reruns the entire job; individual failed tasks can't be targeted. Started a full execution of job %q.", a.Infra.JobName)
+	}
+	return &workspace.ActionResult{
+		Status:  "started",
+		Message: msg,
+		Data:    data,
+	}, nil
+}
+
+func (a Actioner) executionName(executionId string) string {
+	return fmt.Sprintf("%s/executions/%s", a.Infra.JobId, executionId)
+}

--- a/gcp/cloudrun/actioner_test.go
+++ b/gcp/cloudrun/actioner_test.go
@@ -1,0 +1,43 @@
+package cloudrun
+
+import (
+	"testing"
+
+	"cloud.google.com/go/run/apiv2/runpb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildTrafficTargets(t *testing.T) {
+	t.Run("100 percent -> single revision target", func(t *testing.T) {
+		got := buildTrafficTargets("svc-00012-abc", 100, "svc-00012-abc")
+		assert.Equal(t, []*runpb.TrafficTarget{
+			{Type: runpb.TrafficTargetAllocationType_TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION, Revision: "svc-00012-abc", Percent: 100},
+		}, got)
+	})
+	t.Run("partial -> remainder to latest ready revision", func(t *testing.T) {
+		got := buildTrafficTargets("svc-00012-abc", 30, "svc-00013-def")
+		assert.Equal(t, []*runpb.TrafficTarget{
+			{Type: runpb.TrafficTargetAllocationType_TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION, Revision: "svc-00012-abc", Percent: 30},
+			{Type: runpb.TrafficTargetAllocationType_TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION, Revision: "svc-00013-def", Percent: 70},
+		}, got)
+	})
+	t.Run("partial -> remainder to LATEST when latest ready is unknown", func(t *testing.T) {
+		got := buildTrafficTargets("svc-00012-abc", 30, "")
+		assert.Equal(t, []*runpb.TrafficTarget{
+			{Type: runpb.TrafficTargetAllocationType_TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION, Revision: "svc-00012-abc", Percent: 30},
+			{Type: runpb.TrafficTargetAllocationType_TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST, Percent: 70},
+		}, got)
+	})
+	t.Run("partial -> remainder to LATEST when latest ready is the target", func(t *testing.T) {
+		got := buildTrafficTargets("svc-00012-abc", 40, "svc-00012-abc")
+		assert.Equal(t, []*runpb.TrafficTarget{
+			{Type: runpb.TrafficTargetAllocationType_TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION, Revision: "svc-00012-abc", Percent: 40},
+			{Type: runpb.TrafficTargetAllocationType_TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST, Percent: 60},
+		}, got)
+	})
+}
+
+func TestExecutionName(t *testing.T) {
+	a := Actioner{Infra: Outputs{JobId: "projects/p/locations/us-east1/jobs/migrate"}}
+	assert.Equal(t, "projects/p/locations/us-east1/jobs/migrate/executions/migrate-abc12", a.executionName("migrate-abc12"))
+}

--- a/gcp/cloudrun/clients.go
+++ b/gcp/cloudrun/clients.go
@@ -3,6 +3,7 @@ package cloudrun
 import (
 	"context"
 
+	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
 	run "cloud.google.com/go/run/apiv2"
 	"github.com/nullstone-io/deployment-sdk/gcp"
 	"google.golang.org/api/option"
@@ -50,4 +51,12 @@ func NewTasksClient(ctx context.Context, account gcp.ServiceAccount) (*run.Tasks
 		return nil, err
 	}
 	return run.NewTasksClient(ctx, option.WithTokenSource(tokenSource))
+}
+
+func NewMetricClient(ctx context.Context, account gcp.ServiceAccount) (*monitoring.MetricClient, error) {
+	tokenSource, err := account.TokenSource(ctx, GcpScopes...)
+	if err != nil {
+		return nil, err
+	}
+	return monitoring.NewMetricClient(ctx, option.WithTokenSource(tokenSource))
 }

--- a/gcp/cloudrun/clients.go
+++ b/gcp/cloudrun/clients.go
@@ -35,3 +35,19 @@ func NewServicesClient(ctx context.Context, account gcp.ServiceAccount) (*run.Se
 	}
 	return run.NewServicesClient(ctx, option.WithTokenSource(tokenSource))
 }
+
+func NewRevisionsClient(ctx context.Context, account gcp.ServiceAccount) (*run.RevisionsClient, error) {
+	tokenSource, err := account.TokenSource(ctx, GcpScopes...)
+	if err != nil {
+		return nil, err
+	}
+	return run.NewRevisionsClient(ctx, option.WithTokenSource(tokenSource))
+}
+
+func NewTasksClient(ctx context.Context, account gcp.ServiceAccount) (*run.TasksClient, error) {
+	tokenSource, err := account.TokenSource(ctx, GcpScopes...)
+	if err != nil {
+		return nil, err
+	}
+	return run.NewTasksClient(ctx, option.WithTokenSource(tokenSource))
+}

--- a/gcp/cloudrun/outputs.go
+++ b/gcp/cloudrun/outputs.go
@@ -1,6 +1,8 @@
 package cloudrun
 
 import (
+	"strings"
+
 	"github.com/nullstone-io/deployment-sdk/docker"
 	"github.com/nullstone-io/deployment-sdk/gcp"
 	"github.com/nullstone-io/deployment-sdk/gcp/creds"
@@ -9,6 +11,8 @@ import (
 )
 
 type Outputs struct {
+	ProjectId         string             `ns:"project_id,optional"`
+	Region            string             `ns:"region,optional"`
 	ServiceId         string             `ns:"service_id,optional"`
 	ServiceName       string             `ns:"service_name,optional"`
 	JobId             string             `ns:"job_id,optional"`
@@ -16,6 +20,35 @@ type Outputs struct {
 	ImageRepoUrl      docker.ImageUrl    `ns:"image_repo_url,optional"`
 	Deployer          gcp.ServiceAccount `ns:"deployer"`
 	MainContainerName string             `ns:"main_container_name,optional"`
+}
+
+// Location returns the project and region for this workspace. When the
+// project_id/region outputs are absent, it falls back to parsing them from the
+// service_id/job_id, which use the form
+// projects/{project}/locations/{region}/{services|jobs}/{name}.
+func (o Outputs) Location() LocationInfo {
+	loc := LocationInfo{ProjectId: o.ProjectId, Region: o.Region}
+	if loc.ProjectId != "" && loc.Region != "" {
+		return loc
+	}
+	id := o.ServiceId
+	if id == "" {
+		id = o.JobId
+	}
+	parts := strings.Split(id, "/")
+	for i := 0; i+1 < len(parts); i++ {
+		switch parts[i] {
+		case "projects":
+			if loc.ProjectId == "" {
+				loc.ProjectId = parts[i+1]
+			}
+		case "locations":
+			if loc.Region == "" {
+				loc.Region = parts[i+1]
+			}
+		}
+	}
+	return loc
 }
 
 func (o *Outputs) InitializeCreds(source outputs.RetrieverSource, ws *types.Workspace) {

--- a/gcp/cloudrun/status_job.go
+++ b/gcp/cloudrun/status_job.go
@@ -1,0 +1,221 @@
+package cloudrun
+
+import (
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/run/apiv2/runpb"
+	"github.com/nullstone-io/deployment-sdk/docker"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/api/iterator"
+)
+
+const (
+	// maxExecutions bounds how many historical executions we surface.
+	maxExecutions = 20
+	// maxExecutionsWithTasks bounds the per-task fan-out — we only fetch the
+	// task array for the most-recent executions to cap API calls.
+	maxExecutionsWithTasks = 10
+	// maxTasksPerExecution caps the task array we render for a single execution.
+	maxTasksPerExecution = 500
+)
+
+func (s Statuser) statusJob(ctx context.Context) ([]JobExecution, error) {
+	execClient, err := NewExecutionsClient(ctx, s.Infra.Deployer)
+	if err != nil {
+		return nil, fmt.Errorf("error initializing cloud run executions client: %w", err)
+	}
+	defer execClient.Close()
+
+	rawExecs := make([]*runpb.Execution, 0)
+	it := execClient.ListExecutions(ctx, &runpb.ListExecutionsRequest{Parent: s.Infra.JobId})
+	for len(rawExecs) < maxExecutions {
+		exec, err := it.Next()
+		if err == iterator.Done {
+			break
+		} else if err != nil {
+			return nil, fmt.Errorf("error listing executions: %w", err)
+		}
+		rawExecs = append(rawExecs, exec)
+	}
+
+	executions := make([]JobExecution, len(rawExecs))
+	g, gctx := errgroup.WithContext(ctx)
+	for i, exec := range rawExecs {
+		i, exec := i, exec
+		g.Go(func() error {
+			je := s.mapExecution(exec)
+			if i < maxExecutionsWithTasks {
+				tasks, diag, err := s.listExecutionTasks(gctx, exec.GetName())
+				if err != nil {
+					return err
+				}
+				je.Tasks = tasks
+				je.Failure = deriveExecutionFailure(je, diag)
+			}
+			executions[i] = je
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	return executions, nil
+}
+
+func (s Statuser) mapExecution(exec *runpb.Execution) JobExecution {
+	je := JobExecution{
+		Name:           s.Infra.JobName,
+		ExecutionId:    shortName(exec.GetName()),
+		Phase:          executionPhase(exec),
+		ScheduledAt:    tsToTime(exec.GetCreateTime()),
+		StartedAt:      tsToTime(exec.GetStartTime()),
+		CompletedAt:    tsToTime(exec.GetCompletionTime()),
+		TaskCount:      exec.GetTaskCount(),
+		Parallelism:    exec.GetParallelism(),
+		CompletedCount: exec.GetSucceededCount(),
+		RunningCount:   exec.GetRunningCount(),
+		FailedCount:    exec.GetFailedCount(),
+		RetryCount:     exec.GetRetriedCount(),
+		Tasks:          make([]Task, 0),
+	}
+
+	if tmpl := exec.GetTemplate(); tmpl != nil {
+		je.MaxRetries = tmpl.GetMaxRetries()
+		_, container := GetContainerByName(tmpl.GetContainers(), s.Infra.MainContainerName)
+		if container == nil && len(tmpl.GetContainers()) > 0 {
+			container = tmpl.GetContainers()[0]
+		}
+		if container != nil {
+			je.AppVersion = docker.ParseImageUrl(container.GetImage()).Tag
+		}
+	}
+	return je
+}
+
+// taskDiag accumulates failure signals across an execution's task array so the
+// failure banner can distinguish OOM (exit 137) from other failures.
+type taskDiag struct {
+	failedIndexes []int32
+	oom           bool
+}
+
+func (s Statuser) listExecutionTasks(ctx context.Context, executionName string) ([]Task, taskDiag, error) {
+	client, err := NewTasksClient(ctx, s.Infra.Deployer)
+	if err != nil {
+		return nil, taskDiag{}, fmt.Errorf("error initializing cloud run tasks client: %w", err)
+	}
+	defer client.Close()
+
+	tasks := make([]Task, 0)
+	diag := taskDiag{failedIndexes: make([]int32, 0)}
+	it := client.ListTasks(ctx, &runpb.ListTasksRequest{Parent: executionName})
+	for len(tasks) < maxTasksPerExecution {
+		t, err := it.Next()
+		if err == iterator.Done {
+			break
+		} else if err != nil {
+			return nil, taskDiag{}, fmt.Errorf("error listing tasks: %w", err)
+		}
+		mapped := mapTask(t)
+		tasks = append(tasks, mapped)
+		if mapped.State == TaskStateFailed {
+			diag.failedIndexes = append(diag.failedIndexes, mapped.Index)
+			// Exit 137 (128 + SIGKILL) is the strongest OOM signal Cloud Run gives.
+			if res := t.GetLastAttemptResult(); res != nil && res.GetExitCode() == 137 {
+				diag.oom = true
+			}
+		}
+	}
+	return tasks, diag, nil
+}
+
+func mapTask(t *runpb.Task) Task {
+	return Task{
+		Index:    t.GetIndex(),
+		State:    taskState(t),
+		Attempts: t.GetRetried() + 1,
+	}
+}
+
+func executionPhase(exec *runpb.Execution) JobExecutionPhase {
+	if c := findCondition(exec.GetConditions(), "Completed"); c != nil {
+		switch c.GetState() {
+		case runpb.Condition_CONDITION_SUCCEEDED:
+			return JobExecutionPhaseSucceeded
+		case runpb.Condition_CONDITION_FAILED:
+			return JobExecutionPhaseFailed
+		}
+	}
+	if exec.GetCancelledCount() > 0 && exec.GetRunningCount() == 0 && exec.GetCompletionTime() != nil {
+		return JobExecutionPhaseCancelled
+	}
+	if exec.GetCompletionTime() != nil {
+		if exec.GetFailedCount() > 0 || exec.GetSucceededCount() < exec.GetTaskCount() {
+			return JobExecutionPhaseFailed
+		}
+		return JobExecutionPhaseSucceeded
+	}
+	if exec.GetStartTime() != nil || exec.GetRunningCount() > 0 {
+		return JobExecutionPhaseRunning
+	}
+	return JobExecutionPhaseQueued
+}
+
+func taskState(t *runpb.Task) TaskState {
+	if t.GetCompletionTime() != nil {
+		if res := t.GetLastAttemptResult(); res != nil && res.GetExitCode() == 0 {
+			return TaskStateSucceeded
+		}
+		return TaskStateFailed
+	}
+	if t.GetStartTime() != nil {
+		if t.GetRetried() > 0 {
+			return TaskStateRetrying
+		}
+		return TaskStateRunning
+	}
+	return TaskStateQueued
+}
+
+// deriveExecutionFailure builds the failure banner for a failed execution.
+// OOM is inferred from exit code 137 (SIGKILL) on a failed task — Cloud Run
+// has no authoritative OOMKilled reason like Kubernetes does, so this is a
+// best-effort heuristic. Other failures get a generic task-failure banner.
+func deriveExecutionFailure(je JobExecution, diag taskDiag) *Failure {
+	if je.Phase != JobExecutionPhaseFailed {
+		return nil
+	}
+	count := len(diag.failedIndexes)
+	if count == 0 {
+		count = int(je.FailedCount)
+	}
+	if diag.oom {
+		return &Failure{
+			Code:    FailureOOMKilled,
+			Title:   fmt.Sprintf("OOMKilled (%d task%s)", count, plural(count)),
+			Message: fmt.Sprintf("%d task%s exceeded the memory limit and exhausted retries (exit 137). Raise the memory limit or reduce per-task memory use.", count, plural(count)),
+		}
+	}
+	return &Failure{
+		Code:    FailureJobTaskFailed,
+		Title:   fmt.Sprintf("Task failure (%d task%s)", count, plural(count)),
+		Message: fmt.Sprintf("%d of %d tasks failed and exhausted retries. Inspect the failed-task logs for the exit reason.", je.FailedCount, je.TaskCount),
+	}
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+func findCondition(conditions []*runpb.Condition, conditionType string) *runpb.Condition {
+	for _, c := range conditions {
+		if c.GetType() == conditionType {
+			return c
+		}
+	}
+	return nil
+}

--- a/gcp/cloudrun/status_job.go
+++ b/gcp/cloudrun/status_job.go
@@ -98,6 +98,10 @@ func (s Statuser) mapExecution(exec *runpb.Execution) JobExecution {
 type taskDiag struct {
 	failedIndexes []int32
 	oom           bool
+	// exitCode is the exit code of the first failed task we encounter. It feeds
+	// the failure banner so users see the actual process exit code, not just our
+	// failure-mode label.
+	exitCode *int32
 }
 
 func (s Statuser) listExecutionTasks(ctx context.Context, executionName string) ([]Task, taskDiag, error) {
@@ -121,9 +125,15 @@ func (s Statuser) listExecutionTasks(ctx context.Context, executionName string) 
 		tasks = append(tasks, mapped)
 		if mapped.State == TaskStateFailed {
 			diag.failedIndexes = append(diag.failedIndexes, mapped.Index)
-			// Exit 137 (128 + SIGKILL) is the strongest OOM signal Cloud Run gives.
-			if res := t.GetLastAttemptResult(); res != nil && res.GetExitCode() == 137 {
-				diag.oom = true
+			if res := t.GetLastAttemptResult(); res != nil {
+				code := res.GetExitCode()
+				if diag.exitCode == nil {
+					diag.exitCode = &code
+				}
+				// Exit 137 (128 + SIGKILL) is the strongest OOM signal Cloud Run gives.
+				if code == 137 {
+					diag.oom = true
+				}
 			}
 		}
 	}
@@ -192,15 +202,17 @@ func deriveExecutionFailure(je JobExecution, diag taskDiag) *Failure {
 	}
 	if diag.oom {
 		return &Failure{
-			Code:    FailureOOMKilled,
-			Title:   fmt.Sprintf("OOMKilled (%d task%s)", count, plural(count)),
-			Message: fmt.Sprintf("%d task%s exceeded the memory limit and exhausted retries (exit 137). Raise the memory limit or reduce per-task memory use.", count, plural(count)),
+			Code:     FailureOOMKilled,
+			Title:    fmt.Sprintf("OOMKilled (%d task%s)", count, plural(count)),
+			Message:  fmt.Sprintf("%d task%s exceeded the memory limit and exhausted retries (exit 137). Raise the memory limit or reduce per-task memory use.", count, plural(count)),
+			ExitCode: diag.exitCode,
 		}
 	}
 	return &Failure{
-		Code:    FailureJobTaskFailed,
-		Title:   fmt.Sprintf("Task failure (%d task%s)", count, plural(count)),
-		Message: fmt.Sprintf("%d of %d tasks failed and exhausted retries. Inspect the failed-task logs for the exit reason.", je.FailedCount, je.TaskCount),
+		Code:     FailureJobTaskFailed,
+		Title:    fmt.Sprintf("Task failure (%d task%s)", count, plural(count)),
+		Message:  fmt.Sprintf("%d of %d tasks failed and exhausted retries. Inspect the failed-task logs for the exit reason.", je.FailedCount, je.TaskCount),
+		ExitCode: diag.exitCode,
 	}
 }
 

--- a/gcp/cloudrun/status_metrics.go
+++ b/gcp/cloudrun/status_metrics.go
@@ -1,0 +1,351 @@
+package cloudrun
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"time"
+
+	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
+	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
+	"google.golang.org/api/iterator"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	// metricsWindow is the look-back for all Cloud Monitoring queries. Cloud Run
+	// samples at ~60s, so a short window keeps numbers current while still
+	// capturing at least one aligned point.
+	metricsWindow = 5 * time.Minute
+	// metricsAlignment is the alignment period applied to every aligned series.
+	metricsAlignment = 60 * time.Second
+	// maxInstanceCells caps the synthesized instance cells per revision so a
+	// service scaled to thousands of instances doesn't bloat the payload.
+	maxInstanceCells = 50
+	// degradedErrorRatePercent is the 5xx rate above which a serving service is
+	// reported Degraded rather than Healthy.
+	degradedErrorRatePercent = 5.0
+
+	metricInstanceCount  = "run.googleapis.com/container/instance_count"
+	metricRequestCount   = "run.googleapis.com/request_count"
+	metricRequestLatency = "run.googleapis.com/request_latencies"
+)
+
+// enrichServiceMetrics augments a Service (already populated from the Run v2
+// API) with live data from Cloud Monitoring: per-revision instance counts and
+// synthesized instance cells, plus request-rate / latency / error-rate fields
+// at both the revision and service level.
+//
+// All enrichment is best-effort. The Run v2 API exposes no live instance count
+// or request health, but Cloud Monitoring requires roles/monitoring.viewer,
+// which the deployer service account may lack. On any error we log to stderr
+// and leave the Phase 1 data intact rather than failing the whole status call.
+func (s Statuser) enrichServiceMetrics(ctx context.Context, svc *Service) {
+	if svc == nil || len(svc.Revisions) == 0 {
+		return
+	}
+	stderr := s.OsWriters.Stderr()
+	loc := s.Infra.Location()
+	if loc.ProjectId == "" {
+		fmt.Fprintln(stderr, "cloud run metrics: skipping enrichment (no project id)")
+		return
+	}
+
+	client, err := NewMetricClient(ctx, s.Infra.Deployer)
+	if err != nil {
+		fmt.Fprintf(stderr, "cloud run metrics: skipping enrichment (client init failed): %s\n", err)
+		return
+	}
+	defer client.Close()
+
+	m := metricsEnricher{
+		client:      client,
+		projectName: "projects/" + loc.ProjectId,
+		serviceName: svc.ServiceName,
+		location:    loc.Region,
+		stderr:      stderr,
+	}
+	m.applyInstanceCounts(ctx, svc)
+	m.applyRequestMetrics(ctx, svc)
+	refineServiceState(svc)
+}
+
+// refineServiceState downgrades a Healthy service to Cold or Degraded based on
+// the enriched metrics. It never overrides a Failing state (a revision failed
+// to start) — that signal is stronger than any traffic-derived heuristic.
+func refineServiceState(svc *Service) {
+	if svc.State == ServiceStateFailing {
+		return
+	}
+
+	var instances int32
+	for _, rev := range svc.Revisions {
+		instances += rev.InstanceCount
+	}
+	if rh := svc.RequestHealth; rh != nil {
+		// Sustained 5xx rate on a service taking traffic: serving, but degraded.
+		if rh.RequestsPerSecond > 0 && rh.ErrorRatePercent >= degradedErrorRatePercent {
+			svc.State = ServiceStateDegraded
+			return
+		}
+		// No traffic and no warm instances: scaled to zero.
+		if rh.RequestsPerSecond == 0 && instances == 0 {
+			svc.State = ServiceStateCold
+			return
+		}
+	} else if instances == 0 {
+		svc.State = ServiceStateCold
+	}
+}
+
+type metricsEnricher struct {
+	client      *monitoring.MetricClient
+	projectName string
+	serviceName string
+	location    string
+	stderr      io.Writer
+}
+
+// query runs a ListTimeSeries call scoped to this service+location and returns
+// the resulting (reduced) series. Returns nil on error (logged) so callers
+// degrade gracefully.
+func (m metricsEnricher) query(ctx context.Context, metricType string, aligner monitoringpb.Aggregation_Aligner, reducer monitoringpb.Aggregation_Reducer, groupBy []string) []*monitoringpb.TimeSeries {
+	now := time.Now()
+	filter := fmt.Sprintf(`metric.type=%q AND resource.labels.service_name=%q`, metricType, m.serviceName)
+	if m.location != "" {
+		filter += fmt.Sprintf(` AND resource.labels.location=%q`, m.location)
+	}
+	req := &monitoringpb.ListTimeSeriesRequest{
+		Name:   m.projectName,
+		Filter: filter,
+		Interval: &monitoringpb.TimeInterval{
+			StartTime: timestamppb.New(now.Add(-metricsWindow)),
+			EndTime:   timestamppb.New(now),
+		},
+		Aggregation: &monitoringpb.Aggregation{
+			AlignmentPeriod:    durationpb.New(metricsAlignment),
+			PerSeriesAligner:   aligner,
+			CrossSeriesReducer: reducer,
+			GroupByFields:      groupBy,
+		},
+		View: monitoringpb.ListTimeSeriesRequest_FULL,
+	}
+
+	out := make([]*monitoringpb.TimeSeries, 0)
+	it := m.client.ListTimeSeries(ctx, req)
+	for {
+		ts, err := it.Next()
+		if err == iterator.Done {
+			break
+		} else if err != nil {
+			fmt.Fprintf(m.stderr, "cloud run metrics: query for %s failed: %s\n", metricType, err)
+			return nil
+		}
+		out = append(out, ts)
+	}
+	return out
+}
+
+// applyInstanceCounts populates each revision's live InstanceCount and
+// synthesizes instance cells. The instance_count gauge carries a `state` label
+// of "active" (serving) or "idle" (allocated but parked); we map active to Warm
+// cells and idle to Idle cells.
+func (m metricsEnricher) applyInstanceCounts(ctx context.Context, svc *Service) {
+	series := m.query(ctx, metricInstanceCount,
+		monitoringpb.Aggregation_ALIGN_MEAN,
+		monitoringpb.Aggregation_REDUCE_SUM,
+		[]string{"resource.label.revision_name", "metric.label.state"})
+	if series == nil {
+		return
+	}
+
+	type counts struct{ active, idle int32 }
+	byRev := map[string]*counts{}
+	for _, ts := range series {
+		rev := ts.GetResource().GetLabels()["revision_name"]
+		if rev == "" {
+			continue
+		}
+		v, ok := latestValue(ts)
+		if !ok {
+			continue
+		}
+		c := byRev[rev]
+		if c == nil {
+			c = &counts{}
+			byRev[rev] = c
+		}
+		n := int32(math.Round(v))
+		if ts.GetMetric().GetLabels()["state"] == "idle" {
+			c.idle += n
+		} else {
+			c.active += n
+		}
+	}
+
+	for i := range svc.Revisions {
+		rev := &svc.Revisions[i]
+		c := byRev[rev.Name]
+		if c == nil {
+			continue
+		}
+		rev.InstanceCount = c.active + c.idle
+		rev.Instances = synthesizeInstances(rev, c.active, c.idle)
+	}
+}
+
+// synthesizeInstances builds instance cells for the revision card. Cloud Run
+// reports only aggregate active/idle counts, not per-instance identity, so we
+// fabricate stable cell ids. Counts are capped at maxInstanceCells, preferring
+// to show active instances.
+func synthesizeInstances(rev *Revision, active, idle int32) []Instance {
+	if active+idle <= 0 {
+		// Serving traffic but no instances reported yet: mid cold-start.
+		if rev.TrafficPercent > 0 {
+			return []Instance{{Id: fmt.Sprintf("%s-0", rev.Name), State: InstanceStateCold}}
+		}
+		return make([]Instance, 0)
+	}
+	if active > maxInstanceCells {
+		active = maxInstanceCells
+	}
+	if active+idle > maxInstanceCells {
+		idle = maxInstanceCells - active
+	}
+
+	cells := make([]Instance, 0, active+idle)
+	idx := 0
+	for i := int32(0); i < active; i++ {
+		cells = append(cells, Instance{Id: fmt.Sprintf("%s-%d", rev.Name, idx), State: InstanceStateWarm})
+		idx++
+	}
+	for i := int32(0); i < idle; i++ {
+		cells = append(cells, Instance{Id: fmt.Sprintf("%s-%d", rev.Name, idx), State: InstanceStateIdle})
+		idx++
+	}
+	return cells
+}
+
+// applyRequestMetrics populates per-revision request rate, error rate, and
+// latency percentiles, then rolls them up into the service-level RequestHealth.
+func (m metricsEnricher) applyRequestMetrics(ctx context.Context, svc *Service) {
+	// Request rate per revision and response-code class. ALIGN_RATE yields a
+	// per-second rate; summing the per-class rates gives total rps, and the 5xx
+	// share gives the error rate.
+	rateSeries := m.query(ctx, metricRequestCount,
+		monitoringpb.Aggregation_ALIGN_RATE,
+		monitoringpb.Aggregation_REDUCE_SUM,
+		[]string{"resource.label.revision_name", "metric.label.response_code_class"})
+
+	type reqAgg struct{ total, errors float64 }
+	byRev := map[string]*reqAgg{}
+	for _, ts := range rateSeries {
+		rev := ts.GetResource().GetLabels()["revision_name"]
+		if rev == "" {
+			continue
+		}
+		v, ok := latestValue(ts)
+		if !ok {
+			continue
+		}
+		a := byRev[rev]
+		if a == nil {
+			a = &reqAgg{}
+			byRev[rev] = a
+		}
+		a.total += v
+		if ts.GetMetric().GetLabels()["response_code_class"] == "5xx" {
+			a.errors += v
+		}
+	}
+
+	// Latency percentiles. Aligning each distribution with ALIGN_DELTA and then
+	// reducing with REDUCE_PERCENTILE_* merges the underlying distributions and
+	// computes a true percentile (in milliseconds) per group.
+	p50 := m.percentileByRevision(ctx, monitoringpb.Aggregation_REDUCE_PERCENTILE_50)
+	p95 := m.percentileByRevision(ctx, monitoringpb.Aggregation_REDUCE_PERCENTILE_95)
+
+	var totalRps, totalErrors float64
+	for i := range svc.Revisions {
+		rev := &svc.Revisions[i]
+		if a := byRev[rev.Name]; a != nil {
+			rev.RequestsPerSecond = ptr(a.total)
+			errRate := 0.0
+			if a.total > 0 {
+				errRate = a.errors / a.total * 100
+			}
+			rev.ErrorRatePercent = ptr(errRate)
+			totalRps += a.total
+			totalErrors += a.errors
+		}
+		if v, ok := p50[rev.Name]; ok {
+			rev.P50Ms = ptr(v)
+		}
+		if v, ok := p95[rev.Name]; ok {
+			rev.P95Ms = ptr(v)
+		}
+	}
+
+	// Service-level health. rps/error-rate roll up from the per-revision rates;
+	// latency percentiles are computed over the merged distribution across all
+	// revisions (percentiles are not additive, so they can't be summed).
+	health := RequestHealth{RequestsPerSecond: totalRps}
+	if totalRps > 0 {
+		health.ErrorRatePercent = totalErrors / totalRps * 100
+	}
+	if v, ok := m.percentileOverall(ctx, monitoringpb.Aggregation_REDUCE_PERCENTILE_50); ok {
+		health.P50Ms = v
+	}
+	if v, ok := m.percentileOverall(ctx, monitoringpb.Aggregation_REDUCE_PERCENTILE_95); ok {
+		health.P95Ms = v
+	}
+	svc.RequestHealth = &health
+}
+
+func (m metricsEnricher) percentileByRevision(ctx context.Context, reducer monitoringpb.Aggregation_Reducer) map[string]float64 {
+	out := map[string]float64{}
+	for _, ts := range m.query(ctx, metricRequestLatency, monitoringpb.Aggregation_ALIGN_DELTA, reducer, []string{"resource.label.revision_name"}) {
+		rev := ts.GetResource().GetLabels()["revision_name"]
+		if rev == "" {
+			continue
+		}
+		if v, ok := latestValue(ts); ok {
+			out[rev] = v
+		}
+	}
+	return out
+}
+
+func (m metricsEnricher) percentileOverall(ctx context.Context, reducer monitoringpb.Aggregation_Reducer) (float64, bool) {
+	for _, ts := range m.query(ctx, metricRequestLatency, monitoringpb.Aggregation_ALIGN_DELTA, reducer, nil) {
+		if v, ok := latestValue(ts); ok {
+			return v, true
+		}
+	}
+	return 0, false
+}
+
+// latestValue returns the most recent point's value as a float64. ListTimeSeries
+// returns points newest-first, so index 0 is the latest aligned point.
+func latestValue(ts *monitoringpb.TimeSeries) (float64, bool) {
+	pts := ts.GetPoints()
+	if len(pts) == 0 {
+		return 0, false
+	}
+	v := pts[0].GetValue()
+	if v == nil {
+		return 0, false
+	}
+	switch v.GetValue().(type) {
+	case *monitoringpb.TypedValue_Int64Value:
+		return float64(v.GetInt64Value()), true
+	default:
+		return v.GetDoubleValue(), true
+	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/gcp/cloudrun/status_metrics_test.go
+++ b/gcp/cloudrun/status_metrics_test.go
@@ -1,0 +1,95 @@
+package cloudrun
+
+import (
+	"testing"
+
+	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSynthesizeInstances(t *testing.T) {
+	t.Run("no instances, no traffic -> empty", func(t *testing.T) {
+		got := synthesizeInstances(&Revision{Name: "r", TrafficPercent: 0}, 0, 0)
+		assert.Empty(t, got)
+	})
+	t.Run("no instances but serving -> single cold cell", func(t *testing.T) {
+		got := synthesizeInstances(&Revision{Name: "r", TrafficPercent: 100}, 0, 0)
+		assert.Equal(t, []Instance{{Id: "r-0", State: InstanceStateCold}}, got)
+	})
+	t.Run("active and idle map to warm and idle cells", func(t *testing.T) {
+		got := synthesizeInstances(&Revision{Name: "r"}, 2, 1)
+		assert.Equal(t, []Instance{
+			{Id: "r-0", State: InstanceStateWarm},
+			{Id: "r-1", State: InstanceStateWarm},
+			{Id: "r-2", State: InstanceStateIdle},
+		}, got)
+	})
+	t.Run("caps total at maxInstanceCells, preferring active", func(t *testing.T) {
+		got := synthesizeInstances(&Revision{Name: "r"}, maxInstanceCells+10, 5)
+		assert.Len(t, got, maxInstanceCells)
+		for _, c := range got {
+			assert.Equal(t, InstanceStateWarm, c.State)
+		}
+	})
+	t.Run("caps idle once active fills the budget", func(t *testing.T) {
+		got := synthesizeInstances(&Revision{Name: "r"}, maxInstanceCells-2, 10)
+		assert.Len(t, got, maxInstanceCells)
+		assert.Equal(t, InstanceStateIdle, got[maxInstanceCells-1].State)
+	})
+}
+
+func TestRefineServiceState(t *testing.T) {
+	t.Run("never overrides Failing", func(t *testing.T) {
+		svc := &Service{State: ServiceStateFailing, RequestHealth: &RequestHealth{RequestsPerSecond: 0}}
+		refineServiceState(svc)
+		assert.Equal(t, ServiceStateFailing, svc.State)
+	})
+	t.Run("degraded on sustained 5xx", func(t *testing.T) {
+		svc := &Service{State: ServiceStateHealthy, RequestHealth: &RequestHealth{RequestsPerSecond: 10, ErrorRatePercent: 8}}
+		refineServiceState(svc)
+		assert.Equal(t, ServiceStateDegraded, svc.State)
+	})
+	t.Run("cold when no traffic and no instances", func(t *testing.T) {
+		svc := &Service{State: ServiceStateHealthy, RequestHealth: &RequestHealth{RequestsPerSecond: 0}}
+		refineServiceState(svc)
+		assert.Equal(t, ServiceStateCold, svc.State)
+	})
+	t.Run("healthy when serving below error threshold", func(t *testing.T) {
+		svc := &Service{
+			State:         ServiceStateHealthy,
+			RequestHealth: &RequestHealth{RequestsPerSecond: 5, ErrorRatePercent: 1},
+			Revisions:     []Revision{{InstanceCount: 2}},
+		}
+		refineServiceState(svc)
+		assert.Equal(t, ServiceStateHealthy, svc.State)
+	})
+	t.Run("cold without request health when no instances", func(t *testing.T) {
+		svc := &Service{State: ServiceStateHealthy, Revisions: []Revision{{InstanceCount: 0}}}
+		refineServiceState(svc)
+		assert.Equal(t, ServiceStateCold, svc.State)
+	})
+}
+
+func TestLatestValue(t *testing.T) {
+	t.Run("no points", func(t *testing.T) {
+		_, ok := latestValue(&monitoringpb.TimeSeries{})
+		assert.False(t, ok)
+	})
+	t.Run("reads newest double point", func(t *testing.T) {
+		ts := &monitoringpb.TimeSeries{Points: []*monitoringpb.Point{
+			{Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DoubleValue{DoubleValue: 42.5}}},
+			{Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DoubleValue{DoubleValue: 1}}},
+		}}
+		v, ok := latestValue(ts)
+		assert.True(t, ok)
+		assert.Equal(t, 42.5, v)
+	})
+	t.Run("reads int64 point", func(t *testing.T) {
+		ts := &monitoringpb.TimeSeries{Points: []*monitoringpb.Point{
+			{Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{Int64Value: 7}}},
+		}}
+		v, ok := latestValue(ts)
+		assert.True(t, ok)
+		assert.Equal(t, 7.0, v)
+	})
+}

--- a/gcp/cloudrun/status_service.go
+++ b/gcp/cloudrun/status_service.go
@@ -1,0 +1,229 @@
+package cloudrun
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/run/apiv2/runpb"
+	"github.com/nullstone-io/deployment-sdk/docker"
+	"google.golang.org/api/iterator"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func (s Statuser) statusService(ctx context.Context) (*Service, error) {
+	svcClient, err := NewServicesClient(ctx, s.Infra.Deployer)
+	if err != nil {
+		return nil, fmt.Errorf("error initializing cloud run services client: %w", err)
+	}
+	defer svcClient.Close()
+
+	svc, err := svcClient.GetService(ctx, &runpb.GetServiceRequest{Name: s.Infra.ServiceId})
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving service: %w", err)
+	} else if svc == nil {
+		return nil, fmt.Errorf("cloud run service %q not found", s.Infra.ServiceName)
+	}
+
+	// Index the observed traffic split by revision name.
+	trafficByRev := map[string]*runpb.TrafficTargetStatus{}
+	taggedUrls := make([]RevisionTag, 0)
+	for _, tt := range svc.GetTrafficStatuses() {
+		trafficByRev[tt.GetRevision()] = tt
+		if tt.GetTag() != "" && tt.GetUri() != "" {
+			taggedUrls = append(taggedUrls, RevisionTag{Name: tt.GetTag(), Url: tt.GetUri()})
+		}
+	}
+
+	revClient, err := NewRevisionsClient(ctx, s.Infra.Deployer)
+	if err != nil {
+		return nil, fmt.Errorf("error initializing cloud run revisions client: %w", err)
+	}
+	defer revClient.Close()
+
+	revisions := make([]Revision, 0)
+	it := revClient.ListRevisions(ctx, &runpb.ListRevisionsRequest{Parent: s.Infra.ServiceId})
+	for {
+		rev, err := it.Next()
+		if err == iterator.Done {
+			break
+		} else if err != nil {
+			return nil, fmt.Errorf("error listing revisions: %w", err)
+		}
+		revisions = append(revisions, s.mapRevision(rev, svc, trafficByRev))
+	}
+
+	state := ServiceStateHealthy
+	for _, rev := range revisions {
+		if rev.Role == RevisionRoleFailed {
+			state = ServiceStateFailing
+			break
+		}
+	}
+
+	return &Service{
+		ServiceName:    s.Infra.ServiceName,
+		Generation:     svc.GetGeneration(),
+		State:          state,
+		Url:            svc.GetUri(),
+		TaggedUrls:     taggedUrls,
+		LastDeployedAt: tsToTime(svc.GetUpdateTime()),
+		Revisions:      revisions,
+	}, nil
+}
+
+func (s Statuser) mapRevision(rev *runpb.Revision, svc *runpb.Service, trafficByRev map[string]*runpb.TrafficTargetStatus) Revision {
+	name := shortName(rev.GetName())
+	tt := trafficByRev[name]
+	var traffic int32
+	var tag *RevisionTag
+	if tt != nil {
+		traffic = tt.GetPercent()
+		if tt.GetTag() != "" {
+			tag = &RevisionTag{Name: tt.GetTag(), Url: tt.GetUri()}
+		}
+	}
+
+	out := Revision{
+		Name:           name,
+		Label:          deriveRevisionLabel(name, svc.GetName()),
+		CreatedAt:      tsToTime(rev.GetCreateTime()),
+		TrafficPercent: traffic,
+		Tag:            tag,
+		Concurrency:    rev.GetMaxInstanceRequestConcurrency(),
+		Instances:      make([]Instance, 0),
+	}
+	if scaling := rev.GetScaling(); scaling != nil {
+		out.MinInstances = scaling.GetMinInstanceCount()
+		out.MaxInstances = scaling.GetMaxInstanceCount()
+	}
+	// Phase 1: the Run v2 API exposes only the desired minimum, not the live
+	// warm-instance count. Live counts + instance cells arrive in Phase 2 via
+	// Cloud Monitoring.
+	if ss := rev.GetScalingStatus(); ss != nil {
+		out.InstanceCount = ss.GetDesiredMinInstanceCount()
+	}
+
+	_, container := GetContainerByName(rev.GetContainers(), s.Infra.MainContainerName)
+	if container == nil && len(rev.GetContainers()) > 0 {
+		container = rev.GetContainers()[0]
+	}
+	if container != nil {
+		img := docker.ParseImageUrl(container.GetImage())
+		out.AppVersion = img.Tag
+		if limits := container.GetResources().GetLimits(); limits != nil {
+			out.Cpu = limits["cpu"]
+			out.Memory = limits["memory"]
+		}
+	}
+
+	out.Role = s.deriveRevisionRole(rev, svc, traffic, tag)
+	out.Failure = s.deriveRevisionFailure(rev, out.Role)
+	return out
+}
+
+func (s Statuser) deriveRevisionRole(rev *runpb.Revision, svc *runpb.Service, traffic int32, tag *RevisionTag) RevisionRole {
+	name := shortName(rev.GetName())
+	isLatestCreated := name == shortName(svc.GetLatestCreatedRevision())
+
+	if readyConditionFailed(rev.GetConditions()) {
+		return RevisionRoleFailed
+	}
+	if isLatestCreated {
+		if traffic == 0 {
+			// Deployed and healthy, but traffic is pinned to a prior revision.
+			return RevisionRoleStuck
+		}
+		return RevisionRoleLatest
+	}
+	if traffic > 0 {
+		return RevisionRolePrior
+	}
+	if tag != nil {
+		return RevisionRoleTagged
+	}
+	return RevisionRoleIdle
+}
+
+func (s Statuser) deriveRevisionFailure(rev *runpb.Revision, role RevisionRole) *Failure {
+	switch role {
+	case RevisionRoleFailed:
+		msg := readyConditionMessage(rev.GetConditions())
+		if msg == "" {
+			msg = "Container failed to start. Verify the container listens on the port defined by $PORT."
+		}
+		return &Failure{
+			Code:    FailureContainerFailedToStart,
+			Title:   "Container failed to start",
+			Message: msg,
+		}
+	case RevisionRoleStuck:
+		return &Failure{
+			Code:    FailureStuckAtZeroTraffic,
+			Title:   "Deployed, but receiving 0% traffic",
+			Message: "The latest revision is healthy but traffic is pinned to a prior revision. Promote it manually to route traffic.",
+		}
+	}
+	return nil
+}
+
+// readyConditionFailed reports whether the revision's Ready condition is in a
+// failed state.
+func readyConditionFailed(conditions []*runpb.Condition) bool {
+	for _, c := range conditions {
+		if c.GetType() == "Ready" {
+			return c.GetState() == runpb.Condition_CONDITION_FAILED
+		}
+	}
+	return false
+}
+
+func readyConditionMessage(conditions []*runpb.Condition) string {
+	for _, c := range conditions {
+		if c.GetType() == "Ready" {
+			return c.GetMessage()
+		}
+	}
+	return ""
+}
+
+// shortName returns the final path segment of a resource name, e.g.
+// "projects/p/locations/r/services/s/revisions/s-00012-abc" -> "s-00012-abc".
+func shortName(resourceName string) string {
+	if resourceName == "" {
+		return ""
+	}
+	idx := strings.LastIndex(resourceName, "/")
+	if idx < 0 {
+		return resourceName
+	}
+	return resourceName[idx+1:]
+}
+
+// deriveRevisionLabel turns a Cloud Run revision name into a friendly label.
+// Revision names follow "{service}-{NNNNN}-{hash}"; we surface "rev {N}".
+func deriveRevisionLabel(revisionName, serviceName string) string {
+	suffix := strings.TrimPrefix(revisionName, shortName(serviceName)+"-")
+	parts := strings.Split(suffix, "-")
+	if len(parts) > 0 {
+		if n, err := strconv.Atoi(parts[0]); err == nil {
+			return fmt.Sprintf("rev %d", n)
+		}
+	}
+	return revisionName
+}
+
+// tsToTime converts a protobuf timestamp to *time.Time, returning nil for an
+// absent or zero timestamp.
+func tsToTime(ts *timestamppb.Timestamp) *time.Time {
+	if ts == nil {
+		return nil
+	}
+	t := ts.AsTime()
+	if t.IsZero() {
+		return nil
+	}
+	return &t
+}

--- a/gcp/cloudrun/status_test.go
+++ b/gcp/cloudrun/status_test.go
@@ -1,0 +1,251 @@
+package cloudrun
+
+import (
+	"testing"
+	"time"
+
+	"cloud.google.com/go/run/apiv2/runpb"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestOutputsLocation(t *testing.T) {
+	t.Run("uses explicit project_id/region", func(t *testing.T) {
+		o := Outputs{ProjectId: "proj", Region: "us-central1"}
+		assert.Equal(t, LocationInfo{ProjectId: "proj", Region: "us-central1"}, o.Location())
+	})
+	t.Run("parses from service_id", func(t *testing.T) {
+		o := Outputs{ServiceId: "projects/proj/locations/us-east1/services/svc"}
+		assert.Equal(t, LocationInfo{ProjectId: "proj", Region: "us-east1"}, o.Location())
+	})
+	t.Run("parses from job_id", func(t *testing.T) {
+		o := Outputs{JobId: "projects/p2/locations/europe-west1/jobs/j"}
+		assert.Equal(t, LocationInfo{ProjectId: "p2", Region: "europe-west1"}, o.Location())
+	})
+}
+
+func TestShortName(t *testing.T) {
+	assert.Equal(t, "svc-00012-abc", shortName("projects/p/locations/r/services/svc/revisions/svc-00012-abc"))
+	assert.Equal(t, "bare", shortName("bare"))
+	assert.Equal(t, "", shortName(""))
+}
+
+func TestDeriveRevisionLabel(t *testing.T) {
+	assert.Equal(t, "rev 12", deriveRevisionLabel("fortuna-api-00012-abc", "fortuna-api"))
+	assert.Equal(t, "rev 7", deriveRevisionLabel("fortuna-api-00007-xyz", "projects/p/locations/r/services/fortuna-api"))
+	// Unparseable suffix falls back to the raw name.
+	assert.Equal(t, "weird-name", deriveRevisionLabel("weird-name", "svc"))
+}
+
+func makeRevision(name string, opts func(*runpb.Revision)) *runpb.Revision {
+	rev := &runpb.Revision{
+		Name:       name,
+		CreateTime: timestamppb.New(time.Now()),
+		Conditions: []*runpb.Condition{
+			{Type: "Ready", State: runpb.Condition_CONDITION_SUCCEEDED},
+		},
+	}
+	if opts != nil {
+		opts(rev)
+	}
+	return rev
+}
+
+func TestDeriveRevisionRole(t *testing.T) {
+	s := Statuser{}
+	svc := &runpb.Service{Name: "svc", LatestCreatedRevision: "svc-00005-aaa"}
+
+	t.Run("latest serving", func(t *testing.T) {
+		rev := makeRevision("svc-00005-aaa", nil)
+		assert.Equal(t, RevisionRoleLatest, s.deriveRevisionRole(rev, svc, 100, nil))
+	})
+	t.Run("latest deployed but 0% traffic is stuck", func(t *testing.T) {
+		rev := makeRevision("svc-00005-aaa", nil)
+		assert.Equal(t, RevisionRoleStuck, s.deriveRevisionRole(rev, svc, 0, nil))
+	})
+	t.Run("prior serving", func(t *testing.T) {
+		rev := makeRevision("svc-00004-bbb", nil)
+		assert.Equal(t, RevisionRolePrior, s.deriveRevisionRole(rev, svc, 100, nil))
+	})
+	t.Run("tagged with no traffic", func(t *testing.T) {
+		rev := makeRevision("svc-00003-ccc", nil)
+		tag := &RevisionTag{Name: "preview", Url: "https://preview---svc.run.app"}
+		assert.Equal(t, RevisionRoleTagged, s.deriveRevisionRole(rev, svc, 0, tag))
+	})
+	t.Run("idle", func(t *testing.T) {
+		rev := makeRevision("svc-00002-ddd", nil)
+		assert.Equal(t, RevisionRoleIdle, s.deriveRevisionRole(rev, svc, 0, nil))
+	})
+	t.Run("failed Ready condition wins over everything", func(t *testing.T) {
+		rev := makeRevision("svc-00005-aaa", func(r *runpb.Revision) {
+			r.Conditions = []*runpb.Condition{{Type: "Ready", State: runpb.Condition_CONDITION_FAILED}}
+		})
+		assert.Equal(t, RevisionRoleFailed, s.deriveRevisionRole(rev, svc, 100, nil))
+	})
+}
+
+func TestMapRevision(t *testing.T) {
+	s := Statuser{Infra: Outputs{MainContainerName: "main"}}
+	svc := &runpb.Service{Name: "fortuna-api", LatestCreatedRevision: "fortuna-api-00012-abc"}
+	rev := makeRevision("fortuna-api-00012-abc", func(r *runpb.Revision) {
+		r.MaxInstanceRequestConcurrency = 80
+		r.Scaling = &runpb.RevisionScaling{MinInstanceCount: 1, MaxInstanceCount: 100}
+		r.ScalingStatus = &runpb.RevisionScalingStatus{DesiredMinInstanceCount: 3}
+		r.Containers = []*runpb.Container{
+			{
+				Name:  "main",
+				Image: "us-docker.pkg.dev/proj/repo/app:v1.2.3",
+				Resources: &runpb.ResourceRequirements{
+					Limits: map[string]string{"cpu": "1", "memory": "512Mi"},
+				},
+			},
+		}
+	})
+	traffic := map[string]*runpb.TrafficTargetStatus{
+		"fortuna-api-00012-abc": {Revision: "fortuna-api-00012-abc", Percent: 95},
+	}
+
+	out := s.mapRevision(rev, svc, traffic)
+	assert.Equal(t, "fortuna-api-00012-abc", out.Name)
+	assert.Equal(t, "rev 12", out.Label)
+	assert.Equal(t, "v1.2.3", out.AppVersion)
+	assert.Equal(t, int32(95), out.TrafficPercent)
+	assert.Equal(t, int32(80), out.Concurrency)
+	assert.Equal(t, int32(1), out.MinInstances)
+	assert.Equal(t, int32(100), out.MaxInstances)
+	assert.Equal(t, int32(3), out.InstanceCount)
+	assert.Equal(t, "1", out.Cpu)
+	assert.Equal(t, "512Mi", out.Memory)
+	assert.Equal(t, RevisionRoleLatest, out.Role)
+	assert.Nil(t, out.Failure)
+	assert.NotNil(t, out.Instances) // never nil — serializes as []
+}
+
+func TestExecutionPhase(t *testing.T) {
+	now := timestamppb.New(time.Now())
+	cases := []struct {
+		name string
+		exec *runpb.Execution
+		want JobExecutionPhase
+	}{
+		{
+			name: "queued",
+			exec: &runpb.Execution{},
+			want: JobExecutionPhaseQueued,
+		},
+		{
+			name: "running via start time",
+			exec: &runpb.Execution{StartTime: now},
+			want: JobExecutionPhaseRunning,
+		},
+		{
+			name: "succeeded via completed condition",
+			exec: &runpb.Execution{
+				CompletionTime: now,
+				TaskCount:      42, SucceededCount: 42,
+				Conditions: []*runpb.Condition{{Type: "Completed", State: runpb.Condition_CONDITION_SUCCEEDED}},
+			},
+			want: JobExecutionPhaseSucceeded,
+		},
+		{
+			name: "failed via completed condition",
+			exec: &runpb.Execution{
+				CompletionTime: now, TaskCount: 42, SucceededCount: 38, FailedCount: 4,
+				Conditions: []*runpb.Condition{{Type: "Completed", State: runpb.Condition_CONDITION_FAILED}},
+			},
+			want: JobExecutionPhaseFailed,
+		},
+		{
+			name: "failed via counts when no condition",
+			exec: &runpb.Execution{CompletionTime: now, TaskCount: 42, SucceededCount: 38, FailedCount: 4},
+			want: JobExecutionPhaseFailed,
+		},
+		{
+			name: "succeeded via counts when no condition",
+			exec: &runpb.Execution{CompletionTime: now, TaskCount: 42, SucceededCount: 42},
+			want: JobExecutionPhaseSucceeded,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, executionPhase(tc.exec))
+		})
+	}
+}
+
+func TestTaskState(t *testing.T) {
+	now := timestamppb.New(time.Now())
+	t.Run("queued", func(t *testing.T) {
+		assert.Equal(t, TaskStateQueued, taskState(&runpb.Task{}))
+	})
+	t.Run("running", func(t *testing.T) {
+		assert.Equal(t, TaskStateRunning, taskState(&runpb.Task{StartTime: now}))
+	})
+	t.Run("retrying", func(t *testing.T) {
+		assert.Equal(t, TaskStateRetrying, taskState(&runpb.Task{StartTime: now, Retried: 1}))
+	})
+	t.Run("succeeded", func(t *testing.T) {
+		task := &runpb.Task{CompletionTime: now, LastAttemptResult: &runpb.TaskAttemptResult{ExitCode: 0}}
+		assert.Equal(t, TaskStateSucceeded, taskState(task))
+	})
+	t.Run("failed via nonzero exit", func(t *testing.T) {
+		task := &runpb.Task{CompletionTime: now, LastAttemptResult: &runpb.TaskAttemptResult{ExitCode: 137}}
+		assert.Equal(t, TaskStateFailed, taskState(task))
+	})
+}
+
+func TestDeriveExecutionFailure(t *testing.T) {
+	t.Run("nil when not failed", func(t *testing.T) {
+		je := JobExecution{Phase: JobExecutionPhaseSucceeded}
+		assert.Nil(t, deriveExecutionFailure(je, taskDiag{}))
+	})
+	t.Run("OOM when exit 137 detected", func(t *testing.T) {
+		je := JobExecution{Phase: JobExecutionPhaseFailed, TaskCount: 42, FailedCount: 4}
+		diag := taskDiag{failedIndexes: []int32{17, 19, 28, 33}, oom: true}
+		f := deriveExecutionFailure(je, diag)
+		assert.NotNil(t, f)
+		assert.Equal(t, FailureOOMKilled, f.Code)
+		assert.Contains(t, f.Title, "OOMKilled")
+		assert.Contains(t, f.Title, "4 tasks")
+	})
+	t.Run("generic failure otherwise", func(t *testing.T) {
+		je := JobExecution{Phase: JobExecutionPhaseFailed, TaskCount: 10, FailedCount: 1}
+		diag := taskDiag{failedIndexes: []int32{3}}
+		f := deriveExecutionFailure(je, diag)
+		assert.NotNil(t, f)
+		assert.Equal(t, FailureJobTaskFailed, f.Code)
+		assert.Contains(t, f.Title, "1 task")
+	})
+}
+
+func TestMapExecution(t *testing.T) {
+	s := Statuser{Infra: Outputs{JobName: "batch-reindex", MainContainerName: "main"}}
+	now := timestamppb.New(time.Now())
+	exec := &runpb.Execution{
+		Name:           "projects/p/locations/r/jobs/batch-reindex/executions/batch-reindex-0042",
+		CreateTime:     now,
+		StartTime:      now,
+		TaskCount:      42,
+		Parallelism:    8,
+		SucceededCount: 17,
+		RunningCount:   8,
+		RetriedCount:   2,
+		Template: &runpb.TaskTemplate{
+			Retries:    &runpb.TaskTemplate_MaxRetries{MaxRetries: 3},
+			Containers: []*runpb.Container{{Name: "main", Image: "us-docker.pkg.dev/p/repo/app:abc123"}},
+		},
+	}
+
+	je := s.mapExecution(exec)
+	assert.Equal(t, "batch-reindex", je.Name)
+	assert.Equal(t, "batch-reindex-0042", je.ExecutionId)
+	assert.Equal(t, "abc123", je.AppVersion)
+	assert.Equal(t, int32(42), je.TaskCount)
+	assert.Equal(t, int32(8), je.Parallelism)
+	assert.Equal(t, int32(17), je.CompletedCount)
+	assert.Equal(t, int32(8), je.RunningCount)
+	assert.Equal(t, int32(2), je.RetryCount)
+	assert.Equal(t, int32(3), je.MaxRetries)
+	assert.Equal(t, JobExecutionPhaseRunning, je.Phase)
+	assert.NotNil(t, je.Tasks) // never nil
+}

--- a/gcp/cloudrun/status_test.go
+++ b/gcp/cloudrun/status_test.go
@@ -6,6 +6,7 @@ import (
 
 	"cloud.google.com/go/run/apiv2/runpb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -201,20 +202,26 @@ func TestDeriveExecutionFailure(t *testing.T) {
 	})
 	t.Run("OOM when exit 137 detected", func(t *testing.T) {
 		je := JobExecution{Phase: JobExecutionPhaseFailed, TaskCount: 42, FailedCount: 4}
-		diag := taskDiag{failedIndexes: []int32{17, 19, 28, 33}, oom: true}
+		code := int32(137)
+		diag := taskDiag{failedIndexes: []int32{17, 19, 28, 33}, oom: true, exitCode: &code}
 		f := deriveExecutionFailure(je, diag)
 		assert.NotNil(t, f)
 		assert.Equal(t, FailureOOMKilled, f.Code)
 		assert.Contains(t, f.Title, "OOMKilled")
 		assert.Contains(t, f.Title, "4 tasks")
+		require.NotNil(t, f.ExitCode)
+		assert.Equal(t, int32(137), *f.ExitCode)
 	})
 	t.Run("generic failure otherwise", func(t *testing.T) {
 		je := JobExecution{Phase: JobExecutionPhaseFailed, TaskCount: 10, FailedCount: 1}
-		diag := taskDiag{failedIndexes: []int32{3}}
+		code := int32(2)
+		diag := taskDiag{failedIndexes: []int32{3}, exitCode: &code}
 		f := deriveExecutionFailure(je, diag)
 		assert.NotNil(t, f)
 		assert.Equal(t, FailureJobTaskFailed, f.Code)
 		assert.Contains(t, f.Title, "1 task")
+		require.NotNil(t, f.ExitCode)
+		assert.Equal(t, int32(2), *f.ExitCode)
 	})
 }
 

--- a/gcp/cloudrun/status_types.go
+++ b/gcp/cloudrun/status_types.go
@@ -64,6 +64,10 @@ type Failure struct {
 	Code    FailureCode `json:"code"`
 	Title   string      `json:"title"`
 	Message string      `json:"message"`
+	// ExitCode is the process exit code of a failed task, when one is available.
+	// Only set for job-execution failures (Cloud Run service failures have no
+	// single exit code). 137 indicates an OOM kill (128 + SIGKILL).
+	ExitCode *int32 `json:"exitCode,omitempty"`
 }
 
 type Revision struct {

--- a/gcp/cloudrun/status_types.go
+++ b/gcp/cloudrun/status_types.go
@@ -1,0 +1,200 @@
+package cloudrun
+
+import "time"
+
+// LocationInfo identifies where a Cloud Run resource lives. Used by the
+// frontend to build GCP console deep-links.
+type LocationInfo struct {
+	ProjectId string `json:"projectId"`
+	Region    string `json:"region"`
+}
+
+// RevisionRole classifies a revision relative to the current traffic split.
+type RevisionRole string
+
+const (
+	RevisionRoleLatest RevisionRole = "Latest"
+	RevisionRolePrior  RevisionRole = "Prior"
+	RevisionRoleStuck  RevisionRole = "Stuck"
+	RevisionRoleTagged RevisionRole = "Tagged"
+	RevisionRoleFailed RevisionRole = "Failed"
+	RevisionRoleIdle   RevisionRole = "Idle"
+)
+
+// InstanceState describes a single Cloud Run instance. Populated in Phase 2
+// (Cloud Monitoring); empty in Phase 1.
+type InstanceState string
+
+const (
+	InstanceStateWarm     InstanceState = "Warm"
+	InstanceStateStarting InstanceState = "Starting"
+	InstanceStateCold     InstanceState = "Cold"
+	InstanceStateFailed   InstanceState = "Failed"
+	InstanceStateIdle     InstanceState = "Idle"
+)
+
+type Instance struct {
+	Id    string        `json:"id"`
+	State InstanceState `json:"state"`
+}
+
+type RevisionTag struct {
+	Name string `json:"name"`
+	Url  string `json:"url"`
+}
+
+// FailureCode is a display label for a known failure mode. These are not
+// authoritative codes from any catalog — they map observed conditions to the
+// banners the frontend renders. FM-CR-* are Cloud Run service modes; FM-11 is
+// the shared OOMKilled label reused from the K8s job card.
+type FailureCode string
+
+const (
+	FailureContainerFailedToStart FailureCode = "FM-CR-01"
+	FailureImagePullFailed        FailureCode = "FM-CR-02"
+	FailureStuckAtZeroTraffic     FailureCode = "FM-CR-03"
+	FailureErrorRateSpike         FailureCode = "FM-CR-04"
+	FailureThrottledAtMax         FailureCode = "FM-CR-05"
+	FailureColdStartSpike         FailureCode = "FM-CR-06"
+	FailureOOMKilled              FailureCode = "FM-11"
+	FailureJobTaskFailed          FailureCode = "FM-CRJ-01"
+)
+
+type Failure struct {
+	Code    FailureCode `json:"code"`
+	Title   string      `json:"title"`
+	Message string      `json:"message"`
+}
+
+type Revision struct {
+	Name              string       `json:"name"`
+	Label             string       `json:"label"`
+	AppVersion        string       `json:"appVersion,omitempty"`
+	Sha               string       `json:"sha,omitempty"`
+	CreatedAt         *time.Time   `json:"createdAt"`
+	Role              RevisionRole `json:"role"`
+	TrafficPercent    int32        `json:"trafficPercent"`
+	InstanceCount     int32        `json:"instanceCount"`
+	MinInstances      int32        `json:"minInstances"`
+	MaxInstances      int32        `json:"maxInstances"`
+	Concurrency       int32        `json:"concurrency"`
+	Cpu               string       `json:"cpu"`
+	Memory            string       `json:"memory"`
+	Instances         []Instance   `json:"instances"`
+	Tag               *RevisionTag `json:"tag,omitempty"`
+	RequestsPerSecond *float64     `json:"requestsPerSecond,omitempty"`
+	P50Ms             *float64     `json:"p50Ms,omitempty"`
+	P95Ms             *float64     `json:"p95Ms,omitempty"`
+	ErrorRatePercent  *float64     `json:"errorRatePercent,omitempty"`
+	Failure           *Failure     `json:"failure,omitempty"`
+}
+
+type ServiceState string
+
+const (
+	ServiceStateHealthy  ServiceState = "Healthy"
+	ServiceStateScaling  ServiceState = "Scaling"
+	ServiceStateCold     ServiceState = "Cold"
+	ServiceStateFailing  ServiceState = "Failing"
+	ServiceStateDegraded ServiceState = "Degraded"
+)
+
+type RequestHealth struct {
+	RequestsPerSecond float64 `json:"requestsPerSecond"`
+	P50Ms             float64 `json:"p50Ms"`
+	P95Ms             float64 `json:"p95Ms"`
+	ErrorRatePercent  float64 `json:"errorRatePercent"`
+}
+
+type Service struct {
+	ServiceName    string         `json:"serviceName"`
+	Generation     int64          `json:"generation,omitempty"`
+	State          ServiceState   `json:"state"`
+	Url            string         `json:"url"`
+	TaggedUrls     []RevisionTag  `json:"taggedUrls"`
+	LastDeployedAt *time.Time     `json:"lastDeployedAt,omitempty"`
+	RequestHealth  *RequestHealth `json:"requestHealth,omitempty"`
+	Revisions      []Revision     `json:"revisions"`
+}
+
+type TaskState string
+
+const (
+	TaskStateQueued    TaskState = "Queued"
+	TaskStateRunning   TaskState = "Running"
+	TaskStateSucceeded TaskState = "Succeeded"
+	TaskStateFailed    TaskState = "Failed"
+	TaskStateRetrying  TaskState = "Retrying"
+	TaskStateSkipped   TaskState = "Skipped"
+)
+
+type Task struct {
+	Index    int32     `json:"index"`
+	State    TaskState `json:"state"`
+	Attempts int32     `json:"attempts"`
+}
+
+type JobExecutionPhase string
+
+const (
+	JobExecutionPhaseQueued    JobExecutionPhase = "Queued"
+	JobExecutionPhaseRunning   JobExecutionPhase = "Running"
+	JobExecutionPhaseSucceeded JobExecutionPhase = "Succeeded"
+	JobExecutionPhaseFailed    JobExecutionPhase = "Failed"
+	JobExecutionPhaseCancelled JobExecutionPhase = "Cancelled"
+)
+
+type JobExecution struct {
+	Name           string            `json:"name"`
+	ExecutionId    string            `json:"executionId"`
+	AppVersion     string            `json:"appVersion,omitempty"`
+	Sha            string            `json:"sha,omitempty"`
+	Phase          JobExecutionPhase `json:"phase"`
+	ScheduledAt    *time.Time        `json:"scheduledAt,omitempty"`
+	StartedAt      *time.Time        `json:"startedAt,omitempty"`
+	CompletedAt    *time.Time        `json:"completedAt,omitempty"`
+	ScheduledBy    string            `json:"scheduledBy,omitempty"`
+	TaskCount      int32             `json:"taskCount"`
+	Parallelism    int32             `json:"parallelism"`
+	CompletedCount int32             `json:"completedCount"`
+	RunningCount   int32             `json:"runningCount"`
+	FailedCount    int32             `json:"failedCount"`
+	RetryCount     int32             `json:"retryCount"`
+	MaxRetries     int32             `json:"maxRetries"`
+	Tasks          []Task            `json:"tasks"`
+	Failure        *Failure          `json:"failure,omitempty"`
+}
+
+// Status is the full app status payload (the `data` field on the frontend
+// AppStatusResult). A service workspace populates Service; a job workspace
+// populates Executions.
+type Status struct {
+	Location    LocationInfo   `json:"location"`
+	ServiceName string         `json:"serviceName"`
+	JobName     string         `json:"jobName"`
+	Service     *Service       `json:"service,omitempty"`
+	Executions  []JobExecution `json:"executions"`
+}
+
+type TrafficSplitEntry struct {
+	RevisionName   string `json:"revisionName"`
+	TrafficPercent int32  `json:"trafficPercent"`
+}
+
+// StatusOverview is the lightweight `overview` field on the frontend
+// AppStatusResult and implements app.StatusOverviewResult.
+type StatusOverview struct {
+	Location             LocationInfo        `json:"location"`
+	ServiceName          string              `json:"serviceName"`
+	JobName              string              `json:"jobName"`
+	ServingRevisionCount int                 `json:"servingRevisionCount"`
+	TrafficSplit         []TrafficSplitEntry `json:"trafficSplit"`
+	versions             []string
+}
+
+func (s StatusOverview) GetDeploymentVersions() []string {
+	if s.versions == nil {
+		return make([]string, 0)
+	}
+	return s.versions
+}

--- a/gcp/cloudrun/statuser.go
+++ b/gcp/cloudrun/statuser.go
@@ -10,20 +10,7 @@ import (
 
 var (
 	_ app.StatusOverviewResult = StatusOverview{}
-)
-
-type StatusOverview struct {
-}
-
-func (s StatusOverview) GetDeploymentVersions() []string {
-	return make([]string, 0)
-}
-
-type Status struct {
-}
-
-var (
-	_ app.Statuser = &Statuser{}
+	_ app.Statuser             = Statuser{}
 )
 
 func NewStatuser(ctx context.Context, osWriters logging.OsWriters, source outputs.RetrieverSource, appDetails app.Details) (app.Statuser, error) {
@@ -47,11 +34,69 @@ type Statuser struct {
 }
 
 func (s Statuser) StatusOverview(ctx context.Context) (app.StatusOverviewResult, error) {
-	// TODO: Implement when ServiceName != ""
-	return StatusOverview{}, nil
+	ov := StatusOverview{
+		Location:     s.Infra.Location(),
+		ServiceName:  s.Infra.ServiceName,
+		JobName:      s.Infra.JobName,
+		TrafficSplit: make([]TrafficSplitEntry, 0),
+	}
+
+	if s.Infra.ServiceName != "" {
+		svc, err := s.statusService(ctx)
+		if err != nil {
+			return ov, err
+		}
+		versions := make([]string, 0)
+		for _, rev := range svc.Revisions {
+			if rev.TrafficPercent <= 0 && rev.Role != RevisionRoleLatest {
+				continue
+			}
+			ov.TrafficSplit = append(ov.TrafficSplit, TrafficSplitEntry{
+				RevisionName:   rev.Name,
+				TrafficPercent: rev.TrafficPercent,
+			})
+			if rev.TrafficPercent > 0 {
+				ov.ServingRevisionCount++
+			}
+			if rev.AppVersion != "" {
+				versions = append(versions, rev.AppVersion)
+			}
+		}
+		ov.versions = versions
+		return ov, nil
+	}
+
+	execs, err := s.statusJob(ctx)
+	if err != nil {
+		return ov, err
+	}
+	if len(execs) > 0 && execs[0].AppVersion != "" {
+		ov.versions = []string{execs[0].AppVersion}
+	}
+	return ov, nil
 }
 
 func (s Statuser) Status(ctx context.Context) (any, error) {
-	// TODO: Implement when ServiceName != ""
-	return Status{}, nil
+	out := Status{
+		Location:    s.Infra.Location(),
+		ServiceName: s.Infra.ServiceName,
+		JobName:     s.Infra.JobName,
+		Executions:  make([]JobExecution, 0),
+	}
+
+	if s.Infra.ServiceName != "" {
+		svc, err := s.statusService(ctx)
+		if err != nil {
+			return nil, err
+		}
+		out.Service = svc
+		return out, nil
+	}
+
+	execs, err := s.statusJob(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out.Executions = execs
+	return out, nil
 }

--- a/gcp/cloudrun/statuser.go
+++ b/gcp/cloudrun/statuser.go
@@ -89,6 +89,9 @@ func (s Statuser) Status(ctx context.Context) (any, error) {
 		if err != nil {
 			return nil, err
 		}
+		// Best-effort: layer live instance counts + request health from Cloud
+		// Monitoring on top of the Run v2 data. Failures are logged, not fatal.
+		s.enrichServiceMetrics(ctx, svc)
 		out.Service = svc
 		return out, nil
 	}

--- a/k8s/status_job.go
+++ b/k8s/status_job.go
@@ -29,6 +29,11 @@ type AppStatusJobExecution struct {
 	StartedAt   *time.Time                 `json:"startedAt,omitempty"`
 	CompletedAt *time.Time                 `json:"completedAt,omitempty"`
 	ExitReason  string                     `json:"exitReason,omitempty"`
+	// ExitCode is the process exit code of the failed container, recovered from
+	// the Job's pod. The Job object itself only carries a condition reason
+	// (ExitReason); the numeric code lives on the terminated container state.
+	// Unset when the code can't be determined (e.g. the pod was garbage-collected).
+	ExitCode *int32 `json:"exitCode,omitempty"`
 }
 
 // AppStatusJobSummary aggregates Job phases for the StatusOverview view.
@@ -42,8 +47,10 @@ type AppStatusJobSummary struct {
 
 // AppStatusJobExecutionFromK8s folds a single batchv1.Job into the execution
 // record. Phase is derived from conditions first, then active/succeeded/failed
-// counters as a fallback for pre-condition-set Jobs.
-func AppStatusJobExecutionFromK8s(job batchv1.Job) AppStatusJobExecution {
+// counters as a fallback for pre-condition-set Jobs. pods is the namespace's
+// pod list — on failure we scan it for the Job's pod to recover the container
+// exit code, which the Job object doesn't carry.
+func AppStatusJobExecutionFromK8s(job batchv1.Job, pods []corev1.Pod) AppStatusJobExecution {
 	exec := AppStatusJobExecution{
 		Name:        job.Name,
 		ExecutionId: string(job.UID),
@@ -70,8 +77,54 @@ func AppStatusJobExecutionFromK8s(job batchv1.Job) AppStatusJobExecution {
 				exec.CompletedAt = &t
 			}
 		}
+		exec.ExitCode = jobFailedExitCode(job, pods)
 	}
 	return exec
+}
+
+// jobFailedExitCode finds the non-zero exit code of a container in one of the
+// Job's pods. It returns the first such code found, or nil when no owned pod
+// has a non-zero terminated container (the pod may have been garbage-collected,
+// or the failure was a Job-level condition like DeadlineExceeded with no pod).
+func jobFailedExitCode(job batchv1.Job, pods []corev1.Pod) *int32 {
+	for i := range pods {
+		if !podOwnedByJob(pods[i], job) {
+			continue
+		}
+		if code := podTerminatedExitCode(pods[i]); code != nil {
+			return code
+		}
+	}
+	return nil
+}
+
+// podOwnedByJob reports whether pod is a child of job, matched on the controller
+// owner reference UID (robust across the job-name label rename in k8s 1.27).
+func podOwnedByJob(pod corev1.Pod, job batchv1.Job) bool {
+	for _, or := range pod.OwnerReferences {
+		if or.Kind == "Job" && or.UID == job.UID {
+			return true
+		}
+	}
+	return false
+}
+
+// podTerminatedExitCode returns the first non-zero exit code among the pod's
+// containers, preferring the current terminated state over the last one. Zero
+// exit codes are skipped so a sidecar that exited cleanly doesn't mask the
+// real failure.
+func podTerminatedExitCode(pod corev1.Pod) *int32 {
+	for _, cs := range pod.Status.ContainerStatuses {
+		if t := cs.State.Terminated; t != nil && t.ExitCode != 0 {
+			code := t.ExitCode
+			return &code
+		}
+		if t := cs.LastTerminationState.Terminated; t != nil && t.ExitCode != 0 {
+			code := t.ExitCode
+			return &code
+		}
+	}
+	return nil
 }
 
 // jobPhase classifies a Job into our 4-state enum. Conditions are authoritative

--- a/k8s/status_job_test.go
+++ b/k8s/status_job_test.go
@@ -109,7 +109,7 @@ func TestAppStatusJobExecutionFromK8s(t *testing.T) {
 				},
 			},
 		}
-		got := AppStatusJobExecutionFromK8s(job)
+		got := AppStatusJobExecutionFromK8s(job, nil)
 		assert.Equal(t, "nightly-sync", got.Name)
 		assert.Equal(t, "uid-1", got.ExecutionId)
 		assert.Equal(t, "v1.2.3", got.AppVersion)
@@ -138,19 +138,84 @@ func TestAppStatusJobExecutionFromK8s(t *testing.T) {
 				}},
 			},
 		}
-		got := AppStatusJobExecutionFromK8s(job)
+		got := AppStatusJobExecutionFromK8s(job, nil)
 		assert.Equal(t, JobPhaseFailed, got.Phase)
 		assert.Equal(t, "BackoffLimitExceeded: Job has reached the specified backoff limit", got.ExitReason)
 		// CompletionTime is unset for failed Jobs; we fall back to the failure transition time.
 		require.NotNil(t, got.CompletedAt)
 		assert.Equal(t, failedAt.Time, *got.CompletedAt)
+		// No pods supplied -> exit code can't be recovered.
+		assert.Nil(t, got.ExitCode)
+	})
+
+	t.Run("failed recovers exit code from the job's pod", func(t *testing.T) {
+		job := batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "broken-job", UID: types.UID("uid-2"), CreationTimestamp: created},
+			Status: batchv1.JobStatus{
+				StartTime: &started,
+				Conditions: []batchv1.JobCondition{{
+					Type: batchv1.JobFailed, Status: corev1.ConditionTrue, Reason: "BackoffLimitExceeded",
+				}},
+			},
+		}
+		pods := []corev1.Pod{
+			// An unrelated pod (different owner) must be ignored.
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "other",
+					OwnerReferences: []metav1.OwnerReference{{Kind: "Job", UID: types.UID("uid-other")}},
+				},
+				Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+					{State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 7}}},
+				}},
+			},
+			// The job's pod: clean sidecar (0) is skipped, the crashing container (137) wins.
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "broken-job-abc",
+					OwnerReferences: []metav1.OwnerReference{{Kind: "Job", UID: types.UID("uid-2")}},
+				},
+				Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+					{Name: "sidecar", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 0}}},
+					{Name: "main", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 137}}},
+				}},
+			},
+		}
+		got := AppStatusJobExecutionFromK8s(job, pods)
+		assert.Equal(t, JobPhaseFailed, got.Phase)
+		require.NotNil(t, got.ExitCode)
+		assert.Equal(t, int32(137), *got.ExitCode)
+	})
+
+	t.Run("exit code falls back to lastTerminationState (CrashLoopBackOff)", func(t *testing.T) {
+		job := batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "crashloop-job", UID: types.UID("uid-4"), CreationTimestamp: created},
+			Status: batchv1.JobStatus{
+				StartTime:  &started,
+				Conditions: []batchv1.JobCondition{{Type: batchv1.JobFailed, Status: corev1.ConditionTrue}},
+			},
+		}
+		pods := []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "crashloop-job-xyz",
+				OwnerReferences: []metav1.OwnerReference{{Kind: "Job", UID: types.UID("uid-4")}},
+			},
+			Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{
+				Name:                 "main",
+				State:                corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}},
+				LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 1}},
+			}}},
+		}}
+		got := AppStatusJobExecutionFromK8s(job, pods)
+		require.NotNil(t, got.ExitCode)
+		assert.Equal(t, int32(1), *got.ExitCode)
 	})
 
 	t.Run("queued has only ScheduledAt", func(t *testing.T) {
 		job := batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{Name: "pending-job", UID: types.UID("uid-3"), CreationTimestamp: created},
 		}
-		got := AppStatusJobExecutionFromK8s(job)
+		got := AppStatusJobExecutionFromK8s(job, nil)
 		assert.Equal(t, JobPhaseQueued, got.Phase)
 		require.NotNil(t, got.ScheduledAt)
 		assert.Nil(t, got.StartedAt)

--- a/k8s/statuser.go
+++ b/k8s/statuser.go
@@ -140,7 +140,7 @@ func (s *Statuser) Status(ctx context.Context) (any, error) {
 	}
 
 	for _, job := range s.jobs {
-		st.Jobs = append(st.Jobs, AppStatusJobExecutionFromK8s(job))
+		st.Jobs = append(st.Jobs, AppStatusJobExecutionFromK8s(job, s.pods))
 	}
 
 	// Surface rollout-level failures (ProgressDeadlineExceeded / ReplicaFailure)

--- a/workspace/all/actioners.go
+++ b/workspace/all/actioners.go
@@ -4,9 +4,11 @@ import (
 	aws_ecs_ec2_provider "github.com/nullstone-io/deployment-sdk/app/container/aws-ecs-ec2"
 	aws_ecs_fargate_provider "github.com/nullstone-io/deployment-sdk/app/container/aws-ecs-fargate"
 	aws_eks_provider "github.com/nullstone-io/deployment-sdk/app/container/aws-eks"
+	gcp_cloudrun_provider "github.com/nullstone-io/deployment-sdk/app/container/gcp-cloudrun"
 	gcp_gke_service "github.com/nullstone-io/deployment-sdk/app/container/gcp-gke-service"
 	"github.com/nullstone-io/deployment-sdk/aws/ecs"
 	"github.com/nullstone-io/deployment-sdk/aws/eks"
+	"github.com/nullstone-io/deployment-sdk/gcp/cloudrun"
 	"github.com/nullstone-io/deployment-sdk/gcp/gke"
 	"github.com/nullstone-io/deployment-sdk/workspace"
 )
@@ -17,6 +19,7 @@ var (
 	Actioners = workspace.Actioners{
 		aws_eks_provider.ModuleContractName:         eks.NewActioner,
 		gcp_gke_service.ModuleContractName:          gke.NewActioner,
+		gcp_cloudrun_provider.ModuleContractName:    cloudrun.NewActioner,
 		aws_ecs_fargate_provider.ModuleContractName: ecs.NewActioner,
 		aws_ecs_ec2_provider.ModuleContractName:     ecs.NewActioner,
 	}


### PR DESCRIPTION
This adds an actioner and statuser for cloud run jobs and services.
This is used to create the Deployments section of the Monitoring tab in the UI.

The log streamer was enhanced to support "execution" and "revision" input params to filter logs.

