### PR TITLE
Fix/improve cloudrun validation

### DIFF
--- a/gcp/cloudrun/actioner.go
+++ b/gcp/cloudrun/actioner.go
@@ -263,7 +263,7 @@ func buildTrafficTargets(revisionName string, percent int32, latestReady string)
 // cancelExecution cancels a running job execution. It waits for the cancel to
 // be acknowledged so the caller gets a real confirmation (or the failure).
 func (a Actioner) cancelExecution(ctx context.Context, input json.RawMessage) (*workspace.ActionResult, error) {
-	if a.Infra.JobName == "" {
+	if a.Infra.JobId == "" {
 		return nil, fmt.Errorf("%s requires a job workspace", ActionCancelExecution)
 	}
 	var in CancelExecutionInput
@@ -306,7 +306,7 @@ func (a Actioner) cancelExecution(ctx context.Context, input json.RawMessage) (*
 // whole job is re-executed and the result message says so. (The job's own
 // per-task retry policy handles transient task failures within an execution.)
 func (a Actioner) rerunJob(ctx context.Context, input json.RawMessage) (*workspace.ActionResult, error) {
-	if a.Infra.JobName == "" {
+	if a.Infra.JobId == "" {
 		return nil, fmt.Errorf("%s requires a job workspace", ActionRerunJob)
 	}
 	var in RerunJobInput
@@ -324,12 +324,12 @@ func (a Actioner) rerunJob(ctx context.Context, input json.RawMessage) (*workspa
 
 	op, err := client.RunJob(ctx, &runpb.RunJobRequest{Name: a.Infra.JobId})
 	if err != nil {
-		return nil, fmt.Errorf("error running job %q: %w", a.Infra.JobName, err)
+		return nil, fmt.Errorf("error running job %q: %w", a.Infra.JobId, err)
 	}
 	// Don't wait: the execution runs asynchronously and may take a long time.
 
 	data, err := json.Marshal(RerunJobResult{
-		Job:             a.Infra.JobName,
+		Job:             a.Infra.JobName(),
 		SourceExecution: in.ExecutionId,
 		Operation:       op.Name(),
 	})
@@ -337,9 +337,9 @@ func (a Actioner) rerunJob(ctx context.Context, input json.RawMessage) (*workspa
 		return nil, err
 	}
 
-	msg := fmt.Sprintf("started a new execution of job %q", a.Infra.JobName)
+	msg := fmt.Sprintf("started a new execution of job %q", a.Infra.JobId)
 	if in.OnlyFailedTasks {
-		msg = fmt.Sprintf("Cloud Run reruns the entire job; individual failed tasks can't be targeted. Started a full execution of job %q.", a.Infra.JobName)
+		msg = fmt.Sprintf("Cloud Run reruns the entire job; individual failed tasks can't be targeted. Started a full execution of job %q.", a.Infra.JobId)
 	}
 	return &workspace.ActionResult{
 		Status:  "started",

--- a/gcp/cloudrun/actioner.go
+++ b/gcp/cloudrun/actioner.go
@@ -118,7 +118,7 @@ func (a Actioner) PerformAction(ctx context.Context, options workspace.ActionOpt
 // the new revision is created ready-but-idle and can be promoted with
 // route-traffic.
 func (a Actioner) restartRevision(ctx context.Context, input json.RawMessage) (*workspace.ActionResult, error) {
-	if a.Infra.ServiceName == "" {
+	if a.Infra.ServiceId == "" {
 		return nil, fmt.Errorf("%s requires a service workspace", ActionRestartRevision)
 	}
 	var in RestartRevisionInput
@@ -140,7 +140,7 @@ func (a Actioner) restartRevision(ctx context.Context, input json.RawMessage) (*
 	}
 	tmpl := svc.GetTemplate()
 	if tmpl == nil {
-		return nil, fmt.Errorf("service %q has no template to restart", a.Infra.ServiceName)
+		return nil, fmt.Errorf("service %q has no template to restart", a.Infra.ServiceId)
 	}
 
 	// Clear the pinned revision name so the server auto-generates a fresh one,
@@ -155,13 +155,13 @@ func (a Actioner) restartRevision(ctx context.Context, input json.RawMessage) (*
 
 	op, err := client.UpdateService(ctx, &runpb.UpdateServiceRequest{Service: svc})
 	if err != nil {
-		return nil, fmt.Errorf("error restarting service %q: %w", a.Infra.ServiceName, err)
+		return nil, fmt.Errorf("error restarting service %q: %w", a.Infra.ServiceId, err)
 	}
 	// Don't block on the new revision becoming ready; that can take a while. The
 	// status view reflects progress on the next poll.
 
 	data, err := json.Marshal(RestartRevisionResult{
-		Service:      a.Infra.ServiceName,
+		Service:      a.Infra.ServiceName(),
 		FromRevision: in.RevisionName,
 		RestartedAt:  restartedAt,
 		Operation:    op.Name(),
@@ -171,7 +171,7 @@ func (a Actioner) restartRevision(ctx context.Context, input json.RawMessage) (*
 	}
 	return &workspace.ActionResult{
 		Status:  "started",
-		Message: fmt.Sprintf("restart triggered for service %q", a.Infra.ServiceName),
+		Message: fmt.Sprintf("restart triggered for service %q", a.Infra.ServiceId),
 		Data:    data,
 	}, nil
 }
@@ -179,7 +179,7 @@ func (a Actioner) restartRevision(ctx context.Context, input json.RawMessage) (*
 // routeTraffic points `percent` of the service's traffic at revisionName. When
 // percent is less than 100 the remainder is routed to the latest ready revision.
 func (a Actioner) routeTraffic(ctx context.Context, input json.RawMessage) (*workspace.ActionResult, error) {
-	if a.Infra.ServiceName == "" {
+	if a.Infra.ServiceId == "" {
 		return nil, fmt.Errorf("%s requires a service workspace", ActionRouteTraffic)
 	}
 	var in RouteTrafficInput
@@ -216,7 +216,7 @@ func (a Actioner) routeTraffic(ctx context.Context, input json.RawMessage) (*wor
 	}
 
 	data, err := json.Marshal(RouteTrafficResult{
-		Service:      a.Infra.ServiceName,
+		Service:      a.Infra.ServiceName(),
 		RevisionName: in.RevisionName,
 		Percent:      in.Percent,
 	})

--- a/gcp/cloudrun/deploy_watcher.go
+++ b/gcp/cloudrun/deploy_watcher.go
@@ -16,21 +16,24 @@ func NewDeployWatcher(ctx context.Context, osWriters logging.OsWriters, source o
 	}
 	outs.InitializeCreds(source, appDetails.Workspace)
 
-	if outs.ServiceName != "" {
+	if outs.ServiceId != "" {
 		return &ServiceDeployWatcher{
 			OsWriters: osWriters,
 			Details:   appDetails,
 			Infra:     outs,
 		}, nil
-	}
-	return &app.PollingDeployWatcher{
-		OsWriters: osWriters,
-		StatusGetter: &JobDeployLogger{
+	} else if outs.JobId != "" {
+		return &app.PollingDeployWatcher{
 			OsWriters: osWriters,
-			Details:   appDetails,
-			Infra:     outs,
-		},
-	}, nil
+			StatusGetter: &JobDeployLogger{
+				OsWriters: osWriters,
+				Details:   appDetails,
+				Infra:     outs,
+			},
+		}, nil
+	} else {
+		return nil, fmt.Errorf("cannot watch deployment, no service_id or job_id in app module")
+	}
 }
 
 var _ app.DeployWatcher = &ServiceDeployWatcher{}

--- a/gcp/cloudrun/deployer.go
+++ b/gcp/cloudrun/deployer.go
@@ -37,7 +37,7 @@ type Deployer struct {
 func (d Deployer) Print() {
 	stdout, _ := d.OsWriters.Stdout(), d.OsWriters.Stderr()
 	colorstring.Fprintln(stdout, "[bold]Retrieved Cloud Run service outputs")
-	fmt.Fprintf(stdout, "\tservice_name:   %s\n", d.Infra.ServiceName)
+	fmt.Fprintf(stdout, "\tservice_id:     %s\n", d.Infra.ServiceId)
 	fmt.Fprintf(stdout, "\tjob_id:         %s\n", d.Infra.JobId)
 	fmt.Fprintf(stdout, "\timage_repo_url: %s\n", d.Infra.ImageRepoUrl)
 }
@@ -52,12 +52,12 @@ func (d Deployer) Deploy(ctx context.Context, meta app.DeployMetadata) (string, 
 
 	fmt.Fprintln(stdout)
 	fmt.Fprintf(stdout, "Deploying app %q\n", d.Details.App.Name)
-	if d.Infra.ServiceName != "" {
+	if d.Infra.ServiceId != "" {
 		return d.deployService(ctx, meta)
 	} else if d.Infra.JobId != "" {
 		return d.deployJob(ctx, meta)
 	} else {
-		fmt.Fprintf(stdout, "No service_name or job_name in app module. Skipping deployment.\n")
+		fmt.Fprintf(stdout, "No service_id or job_id in app module. Skipping deployment.\n")
 		return "", nil
 	}
 }
@@ -74,7 +74,7 @@ func (d Deployer) deployService(ctx context.Context, meta app.DeployMetadata) (s
 	if err != nil {
 		return "", fmt.Errorf("error retrieving service: %w", err)
 	} else if svc == nil {
-		return "", fmt.Errorf("cloud run service %q not found", d.Infra.ServiceName)
+		return "", fmt.Errorf("cloud run service %q not found", d.Infra.ServiceId)
 	}
 
 	mainContainerIndex, mainContainer := GetContainerByName(svc.Template.Containers, d.Infra.MainContainerName)

--- a/gcp/cloudrun/job_deploy_logger.go
+++ b/gcp/cloudrun/job_deploy_logger.go
@@ -22,11 +22,11 @@ type JobDeployLogger struct {
 func (d *JobDeployLogger) Close() {}
 
 func (d *JobDeployLogger) GetDeployStatus(ctx context.Context, reference string) (app.RolloutStatus, error) {
-	if d.Infra.JobName == "" {
+	if d.Infra.JobId == "" {
 		d.log(LogEvent{
-			Source:  d.Infra.ServiceName,
+			Source:  d.Infra.JobId,
 			At:      time.Now(),
-			Message: `Empty or missing "job_name" output in app module. Skipping check for healthy.`,
+			Message: `Empty or missing "job_id" output in app module. Skipping check for healthy.`,
 		})
 		return app.RolloutStatusComplete, nil
 	}

--- a/gcp/cloudrun/outputs.go
+++ b/gcp/cloudrun/outputs.go
@@ -15,7 +15,6 @@ type Outputs struct {
 	Region            string             `ns:"region,optional"`
 	ServiceId         string             `ns:"service_id,optional"`
 	JobId             string             `ns:"job_id,optional"`
-	JobName           string             `ns:"job_name,optional"`
 	ImageRepoUrl      docker.ImageUrl    `ns:"image_repo_url,optional"`
 	Deployer          gcp.ServiceAccount `ns:"deployer"`
 	MainContainerName string             `ns:"main_container_name,optional"`
@@ -56,6 +55,14 @@ func (o *Outputs) Location() LocationInfo {
 // unset (e.g. a job workspace).
 func (o *Outputs) ServiceName() string {
 	return shortName(o.ServiceId)
+}
+
+// JobName returns the bare job name parsed from job_id. Cloud Run job ids use
+// the form projects/{project}/locations/{region}/jobs/{name}; this returns the
+// final {name} segment, or an empty string when job_id is unset (e.g. a service
+// workspace).
+func (o *Outputs) JobName() string {
+	return shortName(o.JobId)
 }
 
 func (o *Outputs) InitializeCreds(source outputs.RetrieverSource, ws *types.Workspace) {

--- a/gcp/cloudrun/outputs.go
+++ b/gcp/cloudrun/outputs.go
@@ -14,7 +14,6 @@ type Outputs struct {
 	ProjectId         string             `ns:"project_id,optional"`
 	Region            string             `ns:"region,optional"`
 	ServiceId         string             `ns:"service_id,optional"`
-	ServiceName       string             `ns:"service_name,optional"`
 	JobId             string             `ns:"job_id,optional"`
 	JobName           string             `ns:"job_name,optional"`
 	ImageRepoUrl      docker.ImageUrl    `ns:"image_repo_url,optional"`
@@ -26,7 +25,7 @@ type Outputs struct {
 // project_id/region outputs are absent, it falls back to parsing them from the
 // service_id/job_id, which use the form
 // projects/{project}/locations/{region}/{services|jobs}/{name}.
-func (o Outputs) Location() LocationInfo {
+func (o *Outputs) Location() LocationInfo {
 	loc := LocationInfo{ProjectId: o.ProjectId, Region: o.Region}
 	if loc.ProjectId != "" && loc.Region != "" {
 		return loc
@@ -49,6 +48,14 @@ func (o Outputs) Location() LocationInfo {
 		}
 	}
 	return loc
+}
+
+// ServiceName returns the bare service name parsed from service_id. Cloud Run
+// service ids use the form projects/{project}/locations/{region}/services/{name};
+// this returns the final {name} segment, or an empty string when service_id is
+// unset (e.g. a job workspace).
+func (o *Outputs) ServiceName() string {
+	return shortName(o.ServiceId)
 }
 
 func (o *Outputs) InitializeCreds(source outputs.RetrieverSource, ws *types.Workspace) {

--- a/gcp/cloudrun/status_job.go
+++ b/gcp/cloudrun/status_job.go
@@ -65,7 +65,7 @@ func (s Statuser) statusJob(ctx context.Context) ([]JobExecution, error) {
 
 func (s Statuser) mapExecution(exec *runpb.Execution) JobExecution {
 	je := JobExecution{
-		Name:           s.Infra.JobName,
+		Name:           s.Infra.JobName(),
 		ExecutionId:    shortName(exec.GetName()),
 		Phase:          executionPhase(exec),
 		ScheduledAt:    tsToTime(exec.GetCreateTime()),

--- a/gcp/cloudrun/status_service.go
+++ b/gcp/cloudrun/status_service.go
@@ -24,7 +24,7 @@ func (s Statuser) statusService(ctx context.Context) (*Service, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving service: %w", err)
 	} else if svc == nil {
-		return nil, fmt.Errorf("cloud run service %q not found", s.Infra.ServiceName)
+		return nil, fmt.Errorf("cloud run service %q not found", s.Infra.ServiceName())
 	}
 
 	// Index the observed traffic split by revision name.
@@ -64,7 +64,7 @@ func (s Statuser) statusService(ctx context.Context) (*Service, error) {
 	}
 
 	return &Service{
-		ServiceName:    s.Infra.ServiceName,
+		ServiceName:    s.Infra.ServiceName(),
 		Generation:     svc.GetGeneration(),
 		State:          state,
 		Url:            svc.GetUri(),

--- a/gcp/cloudrun/status_test.go
+++ b/gcp/cloudrun/status_test.go
@@ -25,6 +25,28 @@ func TestOutputsLocation(t *testing.T) {
 	})
 }
 
+func TestOutputsServiceName(t *testing.T) {
+	t.Run("parses name from service_id", func(t *testing.T) {
+		o := Outputs{ServiceId: "projects/proj/locations/us-east1/services/fortuna-api"}
+		assert.Equal(t, "fortuna-api", o.ServiceName())
+	})
+	t.Run("empty when service_id is unset", func(t *testing.T) {
+		o := Outputs{JobId: "projects/p/locations/r/jobs/migrate"}
+		assert.Equal(t, "", o.ServiceName())
+	})
+}
+
+func TestOutputsJobName(t *testing.T) {
+	t.Run("parses name from job_id", func(t *testing.T) {
+		o := Outputs{JobId: "projects/proj/locations/europe-west1/jobs/batch-reindex"}
+		assert.Equal(t, "batch-reindex", o.JobName())
+	})
+	t.Run("empty when job_id is unset", func(t *testing.T) {
+		o := Outputs{ServiceId: "projects/p/locations/r/services/svc"}
+		assert.Equal(t, "", o.JobName())
+	})
+}
+
 func TestShortName(t *testing.T) {
 	assert.Equal(t, "svc-00012-abc", shortName("projects/p/locations/r/services/svc/revisions/svc-00012-abc"))
 	assert.Equal(t, "bare", shortName("bare"))
@@ -226,7 +248,7 @@ func TestDeriveExecutionFailure(t *testing.T) {
 }
 
 func TestMapExecution(t *testing.T) {
-	s := Statuser{Infra: Outputs{JobName: "batch-reindex", MainContainerName: "main"}}
+	s := Statuser{Infra: Outputs{JobId: "projects/p/locations/r/jobs/batch-reindex", MainContainerName: "main"}}
 	now := timestamppb.New(time.Now())
 	exec := &runpb.Execution{
 		Name:           "projects/p/locations/r/jobs/batch-reindex/executions/batch-reindex-0042",

--- a/gcp/cloudrun/statuser.go
+++ b/gcp/cloudrun/statuser.go
@@ -37,7 +37,7 @@ func (s Statuser) StatusOverview(ctx context.Context) (app.StatusOverviewResult,
 	ov := StatusOverview{
 		Location:     s.Infra.Location(),
 		ServiceName:  s.Infra.ServiceName(),
-		JobName:      s.Infra.JobName,
+		JobName:      s.Infra.JobName(),
 		TrafficSplit: make([]TrafficSplitEntry, 0),
 	}
 
@@ -80,7 +80,7 @@ func (s Statuser) Status(ctx context.Context) (any, error) {
 	out := Status{
 		Location:    s.Infra.Location(),
 		ServiceName: s.Infra.ServiceName(),
-		JobName:     s.Infra.JobName,
+		JobName:     s.Infra.JobName(),
 		Executions:  make([]JobExecution, 0),
 	}
 

--- a/gcp/cloudrun/statuser.go
+++ b/gcp/cloudrun/statuser.go
@@ -36,12 +36,12 @@ type Statuser struct {
 func (s Statuser) StatusOverview(ctx context.Context) (app.StatusOverviewResult, error) {
 	ov := StatusOverview{
 		Location:     s.Infra.Location(),
-		ServiceName:  s.Infra.ServiceName,
+		ServiceName:  s.Infra.ServiceName(),
 		JobName:      s.Infra.JobName,
 		TrafficSplit: make([]TrafficSplitEntry, 0),
 	}
 
-	if s.Infra.ServiceName != "" {
+	if s.Infra.ServiceId != "" {
 		svc, err := s.statusService(ctx)
 		if err != nil {
 			return ov, err
@@ -79,12 +79,12 @@ func (s Statuser) StatusOverview(ctx context.Context) (app.StatusOverviewResult,
 func (s Statuser) Status(ctx context.Context) (any, error) {
 	out := Status{
 		Location:    s.Infra.Location(),
-		ServiceName: s.Infra.ServiceName,
+		ServiceName: s.Infra.ServiceName(),
 		JobName:     s.Infra.JobName,
 		Executions:  make([]JobExecution, 0),
 	}
 
-	if s.Infra.ServiceName != "" {
+	if s.Infra.ServiceId != "" {
 		svc, err := s.statusService(ctx)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This improves the contract with cloud run services/jobs by using JobId and ServiceId since some operations require the full id (project, location, name). This removes the need for JobName and ServiceName in the module outputs.