### PR TITLE
Fix/lambda deployers

### DIFF
--- a/aws/ecs/arns_test.go
+++ b/aws/ecs/arns_test.go
@@ -26,9 +26,9 @@ func TestParseClusterName(t *testing.T) {
 
 func TestParseTaskDefinition(t *testing.T) {
 	tests := []struct {
-		name        string
-		arn         string
-		wantFamily  string
+		name         string
+		arn          string
+		wantFamily   string
 		wantRevision int32
 	}{
 		{"standard arn", "arn:aws:ecs:us-east-1:123456789012:task-definition/my-app:42", "my-app", 42},

--- a/aws/ecs/statuser.go
+++ b/aws/ecs/statuser.go
@@ -48,8 +48,8 @@ type ClusterInfo struct {
 }
 
 type Status struct {
-	Cluster     ClusterInfo  `json:"cluster"`
-	ServiceName string       `json:"serviceName"`
+	Cluster     ClusterInfo `json:"cluster"`
+	ServiceName string      `json:"serviceName"`
 	// IsJob is true when the workspace is a one-off RunTask workspace (no ECS service).
 	// Frontend uses this to route to the job-executions view rather than the deployments view.
 	IsJob      bool              `json:"isJob"`

--- a/aws/lambda-container/deployer.go
+++ b/aws/lambda-container/deployer.go
@@ -83,7 +83,7 @@ func (d Deployer) Deploy(ctx context.Context, meta app.DeployMetadata) (string, 
 		return "", fmt.Errorf("error updating lambda code version: %w", err)
 	}
 	// Wait for function code version to take effect
-	if err := nslambda.WaitForFunctionChanges(ctx, d.Infra, time.Minute, waitForChangesHeartbeat); err != nil {
+	if err := nslambda.WaitForFunctionChanges(ctx, d.Infra, 12*time.Minute, waitForChangesHeartbeat); err != nil {
 		return "", fmt.Errorf("error waiting for updated lambda configuration: %w", err)
 	}
 	fmt.Fprintf(stdout, "Updated lambda code\n")

--- a/aws/lambda-container/deployer.go
+++ b/aws/lambda-container/deployer.go
@@ -2,6 +2,7 @@ package lambda_container
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -35,29 +36,34 @@ type Deployer struct {
 }
 
 func (d Deployer) Print() {
-	stdout, _ := d.OsWriters.Stdout(), d.OsWriters.Stderr()
-	colorstring.Fprintln(stdout, "[bold]Retrieved Lambda outputs")
-	fmt.Fprintf(stdout, "	region:         %s\n", d.Infra.Region)
-	fmt.Fprintf(stdout, "	lambda_name:    %s\n", d.Infra.LambdaName)
-	fmt.Fprintf(stdout, "	image_repo_url: %s\n", d.Infra.ImageRepoUrl)
+	stderr := d.OsWriters.Stderr()
+	colorstring.Fprintln(stderr, "[bold]Retrieved Lambda outputs")
+	fmt.Fprintf(stderr, "	region:         %s\n", d.Infra.Region)
+	fmt.Fprintf(stderr, "	lambda_name:    %s\n", d.Infra.LambdaName)
+	fmt.Fprintf(stderr, "	image_repo_url: %s\n", d.Infra.ImageRepoUrl)
 }
 
 func (d Deployer) Deploy(ctx context.Context, meta app.DeployMetadata) (string, error) {
-	stdout, _ := d.OsWriters.Stdout(), d.OsWriters.Stderr()
+	stderr := d.OsWriters.Stderr()
 	d.Print()
 
-	waitForChangesHeartbeat := func() {
-		fmt.Fprintf(stdout, "Waiting for AWS to apply changes to lambda...\n")
+	// heartbeat reports, while AWS is still applying a change, what we're waiting on and how long
+	// it has taken so far. AWS does not surface progress, so the elapsed time reassures the user
+	// that the deploy is still running (a container image update can take several minutes).
+	heartbeat := func(activity string) func(elapsed time.Duration) {
+		return func(elapsed time.Duration) {
+			fmt.Fprintf(stderr, "	Waiting for AWS to %s (%s elapsed)\n", activity, elapsed)
+		}
 	}
 
-	fmt.Fprintln(stdout)
-	fmt.Fprintf(stdout, "Deploying app %q\n", d.Details.App.Name)
+	fmt.Fprintln(stderr)
+	colorstring.Fprintf(stderr, "[bold]Deploying app %q\n", d.Details.App.Name)
 	if meta.Version == "" {
 		return "", fmt.Errorf("--version is required to deploy app")
 	}
 
 	// Update lambda function configuration (env vars)
-	fmt.Fprintf(stdout, "Updating lambda environment variables\n")
+	colorstring.Fprintln(stderr, "[bold]Updating environment variables")
 	config, err := nslambda.GetFunctionConfig(ctx, d.Infra)
 	if err != nil {
 		return "", fmt.Errorf("error retrieving lambda configuration: %w", err)
@@ -66,28 +72,35 @@ func (d Deployer) Deploy(ctx context.Context, meta app.DeployMetadata) (string, 
 	env_vars.UpdateStandard(updates.Environment.Variables, meta)
 	if updated, changed := env_vars.ReplaceOtelResourceAttributes(updates.Environment.Variables, meta, false); changed {
 		updates.Environment.Variables = updated
-		fmt.Fprintln(d.OsWriters.Stdout(), "Updating OpenTelemetry resource attributes (service.version and service.commit.sha)")
+		fmt.Fprintln(stderr, "	updating OpenTelemetry resource attributes (service.version and service.commit.sha)")
 	}
 	if err := nslambda.UpdateFunctionConfig(ctx, d.Infra, updates); err != nil {
 		return "", fmt.Errorf("error updating lambda configuration: %w", err)
 	}
 	// Wait for function configuration to take effect
-	if err := nslambda.WaitForFunctionChanges(ctx, d.Infra, time.Minute, waitForChangesHeartbeat); err != nil {
+	if err := nslambda.WaitForFunctionChanges(ctx, d.Infra, time.Minute, heartbeat("apply configuration changes")); err != nil {
 		return "", fmt.Errorf("error waiting for updated lambda configuration: %w", err)
 	}
-	fmt.Fprintf(stdout, "Updated lambda environment variables\n")
+	colorstring.Fprintln(stderr, "[green]Environment variables updated")
 
 	// Update lambda code version
-	fmt.Fprintf(stdout, "Updating lambda code to %q\n", meta.Version)
-	if err := UpdateLambdaVersion(ctx, d.Infra, meta.Version); err != nil {
+	colorstring.Fprintf(stderr, "[bold]Updating container image to version %q\n", meta.Version)
+	imageUri, err := UpdateLambdaVersion(ctx, d.Infra, meta.Version)
+	if err != nil {
 		return "", fmt.Errorf("error updating lambda code version: %w", err)
 	}
+	fmt.Fprintf(stderr, "	image: %s\n", imageUri)
 	// Wait for function code version to take effect
-	if err := nslambda.WaitForFunctionChanges(ctx, d.Infra, 12*time.Minute, waitForChangesHeartbeat); err != nil {
-		return "", fmt.Errorf("error waiting for updated lambda configuration: %w", err)
+	if err := nslambda.WaitForFunctionChanges(ctx, d.Infra, 12*time.Minute, heartbeat("pull and apply the new container image")); err != nil {
+		// A container image update normally finishes in well under a minute; a timeout here means
+		// AWS is taking far longer than expected (large images can be slow for AWS to pull).
+		if errors.Is(err, nslambda.ErrTimeoutWaitingForChanges) {
+			return "", fmt.Errorf("AWS took much longer than expected (over 12 minutes) to apply the new container image. This usually resolves on a retry; large images can be slow for AWS to pull. Please retry the deployment.")
+		}
+		return "", fmt.Errorf("error waiting for updated lambda code: %w", err)
 	}
-	fmt.Fprintf(stdout, "Updated lambda code\n")
+	colorstring.Fprintln(stderr, "[green]Container image updated")
 
-	fmt.Fprintf(stdout, "Deployed app %q\n", d.Details.App.Name)
+	colorstring.Fprintf(stderr, "[bold]Deployed app %q\n", d.Details.App.Name)
 	return "", nil
 }

--- a/aws/lambda-container/update_lambda_version.go
+++ b/aws/lambda-container/update_lambda_version.go
@@ -6,16 +6,19 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
 )
 
-func UpdateLambdaVersion(ctx context.Context, infra Outputs, version string) error {
+// UpdateLambdaVersion points the lambda function at the container image for the given version.
+// It returns the fully-qualified image URI that was deployed so callers can report it.
+func UpdateLambdaVersion(ctx context.Context, infra Outputs, version string) (string, error) {
 	λClient := lambda.NewFromConfig(infra.DeployerAwsConfig())
 	imageUrl := infra.ImageRepoUrl
 	imageUrl.Digest = ""
 	imageUrl.Tag = version
+	imageUri := imageUrl.String()
 	_, err := λClient.UpdateFunctionCode(ctx, &lambda.UpdateFunctionCodeInput{
 		FunctionName: aws.String(infra.LambdaName),
 		DryRun:       false,
 		Publish:      false,
-		ImageUri:     aws.String(imageUrl.String()),
+		ImageUri:     aws.String(imageUri),
 	})
-	return err
+	return imageUri, err
 }

--- a/aws/lambda-zip/deployer.go
+++ b/aws/lambda-zip/deployer.go
@@ -35,29 +35,34 @@ type Deployer struct {
 }
 
 func (d Deployer) Print() {
-	stdout, _ := d.OsWriters.Stdout(), d.OsWriters.Stderr()
-	colorstring.Fprintln(stdout, "[bold]Retrieved Lambda outputs")
-	fmt.Fprintf(stdout, "	region:                %s\n", d.Infra.Region)
-	fmt.Fprintf(stdout, "	lambda_name:           %s\n", d.Infra.LambdaName)
-	fmt.Fprintf(stdout, "	artifacts_bucket_name: %s\n", d.Infra.ArtifactsBucketName)
+	stderr := d.OsWriters.Stderr()
+	colorstring.Fprintln(stderr, "[bold]Retrieved Lambda outputs")
+	fmt.Fprintf(stderr, "	region:                %s\n", d.Infra.Region)
+	fmt.Fprintf(stderr, "	lambda_name:           %s\n", d.Infra.LambdaName)
+	fmt.Fprintf(stderr, "	artifacts_bucket_name: %s\n", d.Infra.ArtifactsBucketName)
 }
 
 func (d Deployer) Deploy(ctx context.Context, meta app.DeployMetadata) (string, error) {
-	stdout, _ := d.OsWriters.Stdout(), d.OsWriters.Stderr()
+	stderr := d.OsWriters.Stderr()
 	d.Print()
 
-	waitForChangesHeartbeat := func() {
-		fmt.Fprintf(stdout, "Waiting for AWS to apply changes to lambda...\n")
+	// heartbeat reports, while AWS is still applying a change, what we're waiting on and how long
+	// it has taken so far. AWS does not surface progress, so the elapsed time reassures the user
+	// that the deploy is still running.
+	heartbeat := func(activity string) func(elapsed time.Duration) {
+		return func(elapsed time.Duration) {
+			fmt.Fprintf(stderr, "	Waiting for AWS to %s (%s elapsed)\n", activity, elapsed)
+		}
 	}
 
-	fmt.Fprintln(stdout)
-	fmt.Fprintf(stdout, "Deploying app %q\n", d.Details.App.Name)
+	fmt.Fprintln(stderr)
+	colorstring.Fprintf(stderr, "[bold]Deploying app %q\n", d.Details.App.Name)
 	if meta.Version == "" {
 		return "", fmt.Errorf("--version is required to deploy app")
 	}
 
 	// Update lambda function configuration (env vars)
-	fmt.Fprintf(stdout, "Updating lambda environment variables\n")
+	colorstring.Fprintln(stderr, "[bold]Updating environment variables")
 	config, err := nslambda.GetFunctionConfig(ctx, d.Infra)
 	if err != nil {
 		return "", fmt.Errorf("error retrieving lambda configuration: %w", err)
@@ -66,28 +71,28 @@ func (d Deployer) Deploy(ctx context.Context, meta app.DeployMetadata) (string, 
 	env_vars.UpdateStandard(updates.Environment.Variables, meta)
 	if updated, changed := env_vars.ReplaceOtelResourceAttributes(updates.Environment.Variables, meta, false); changed {
 		updates.Environment.Variables = updated
-		fmt.Fprintln(d.OsWriters.Stdout(), "Updating OpenTelemetry resource attributes (service.version and service.commit.sha)")
+		fmt.Fprintln(stderr, "	updating OpenTelemetry resource attributes (service.version and service.commit.sha)")
 	}
 	if err := nslambda.UpdateFunctionConfig(ctx, d.Infra, updates); err != nil {
 		return "", fmt.Errorf("error updating lambda configuration: %w", err)
 	}
 	// Wait for function configuration to take effect
-	if err := nslambda.WaitForFunctionChanges(ctx, d.Infra, time.Minute, waitForChangesHeartbeat); err != nil {
+	if err := nslambda.WaitForFunctionChanges(ctx, d.Infra, time.Minute, heartbeat("apply configuration changes")); err != nil {
 		return "", fmt.Errorf("error waiting for updated lambda configuration: %w", err)
 	}
-	fmt.Fprintf(stdout, "Updated lambda environment variables\n")
+	colorstring.Fprintln(stderr, "[green]Environment variables updated")
 
 	// Update lambda code version
-	fmt.Fprintf(stdout, "Updating lambda code to %q\n", meta.Version)
+	colorstring.Fprintf(stderr, "[bold]Updating code to version %q\n", meta.Version)
 	if err := UpdateLambdaVersion(ctx, d.Infra, meta.Version); err != nil {
 		return "", fmt.Errorf("error updating lambda version: %w", err)
 	}
 	// Wait for function code version to take effect
-	if err := nslambda.WaitForFunctionChanges(ctx, d.Infra, time.Minute, waitForChangesHeartbeat); err != nil {
-		return "", fmt.Errorf("error waiting for updated lambda configuration: %w", err)
+	if err := nslambda.WaitForFunctionChanges(ctx, d.Infra, time.Minute, heartbeat("apply the new code")); err != nil {
+		return "", fmt.Errorf("error waiting for updated lambda code: %w", err)
 	}
-	fmt.Fprintf(stdout, "Updated lambda code\n")
+	colorstring.Fprintln(stderr, "[green]Code updated")
 
-	fmt.Fprintf(stdout, "Deployed app %q\n", d.Details.App.Name)
+	colorstring.Fprintf(stderr, "[bold]Deployed app %q\n", d.Details.App.Name)
 	return "", nil
 }

--- a/aws/lambda-zip/deployer.go
+++ b/aws/lambda-zip/deployer.go
@@ -2,6 +2,7 @@ package lambda_zip
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -89,6 +90,11 @@ func (d Deployer) Deploy(ctx context.Context, meta app.DeployMetadata) (string, 
 	}
 	// Wait for function code version to take effect
 	if err := nslambda.WaitForFunctionChanges(ctx, d.Infra, time.Minute, heartbeat("apply the new code")); err != nil {
+		// Applying new code normally finishes in well under a minute; a timeout here means AWS is
+		// taking far longer than expected.
+		if errors.Is(err, nslambda.ErrTimeoutWaitingForChanges) {
+			return "", fmt.Errorf("AWS took much longer than expected (over 1 minute) to apply the new code. This usually resolves on a retry. Please retry the deployment.")
+		}
 		return "", fmt.Errorf("error waiting for updated lambda code: %w", err)
 	}
 	colorstring.Fprintln(stderr, "[green]Code updated")

--- a/aws/lambda/wait_for_function_changes.go
+++ b/aws/lambda/wait_for_function_changes.go
@@ -4,25 +4,34 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
 	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
 	"github.com/sethvargo/go-retry"
-	"time"
 )
 
 var (
 	ErrTimeoutWaitingForChanges = errors.New("AWS is taking a long time to update the lambda function. Please retry deployment.")
 	ErrFailedLastChanges        = errors.New("The most recent changes to lambda failed to apply. Please retry deployment.")
+
+	// errChangesInProgress is returned (as a retryable error) while AWS is still applying changes.
+	// When the retry budget is exhausted, retry.Do surfaces this error, which we translate into
+	// ErrTimeoutWaitingForChanges so callers can detect a timeout with errors.Is.
+	errChangesInProgress = errors.New("lambda function is currently making changes")
 )
 
 // WaitForFunctionChanges waits for AWS to finalize changes for a function (configuration or code)
 // See https://docs.aws.amazon.com/lambda/latest/dg/functions-states.html#functions-states-updating
-// During my live tests, this process took <30s
-func WaitForFunctionChanges(ctx context.Context, infra Outputs, timeout time.Duration, heartbeatFn func()) error {
+// During my live tests, this process took <30s (this is longer when deploying larger docker images)
+// heartbeatFn is called on each poll while AWS is still applying changes; it receives the elapsed
+// time since the wait started so callers can report progress.
+func WaitForFunctionChanges(ctx context.Context, infra Outputs, timeout time.Duration, heartbeatFn func(elapsed time.Duration)) error {
 	λClient := lambda.NewFromConfig(infra.DeployerAwsConfig())
+	start := time.Now()
 	b := retry.WithMaxDuration(timeout, retry.NewConstant(5*time.Second))
-	return retry.Do(ctx, b, func(ctx context.Context) error {
+	err := retry.Do(ctx, b, func(ctx context.Context) error {
 		out, err := λClient.GetFunctionConfiguration(ctx, &lambda.GetFunctionConfigurationInput{
 			FunctionName: aws.String(infra.FunctionName()),
 		})
@@ -31,9 +40,13 @@ func WaitForFunctionChanges(ctx context.Context, infra Outputs, timeout time.Dur
 		} else if out != nil {
 			switch out.LastUpdateStatus {
 			case types.LastUpdateStatusInProgress:
-				heartbeatFn()
-				return retry.RetryableError(fmt.Errorf("lambda function is currently making changes"))
+				heartbeatFn(time.Since(start).Round(time.Second))
+				return retry.RetryableError(errChangesInProgress)
 			case types.LastUpdateStatusFailed:
+				// LastUpdateStatusReason explains why AWS rejected the change (e.g. an invalid image)
+				if reason := aws.ToString(out.LastUpdateStatusReason); reason != "" {
+					return fmt.Errorf("%w (reason: %s)", ErrFailedLastChanges, reason)
+				}
 				return ErrFailedLastChanges
 			case types.LastUpdateStatusSuccessful:
 				return nil
@@ -41,4 +54,9 @@ func WaitForFunctionChanges(ctx context.Context, infra Outputs, timeout time.Dur
 		}
 		return nil
 	})
+	// When the retry budget is exhausted, AWS was still applying changes; surface a timeout error.
+	if errors.Is(err, errChangesInProgress) {
+		return ErrTimeoutWaitingForChanges
+	}
+	return err
 }


### PR DESCRIPTION
This makes several improvements to the lambda deployers (zip + container):
- Report logs to stderr (consistent with other deployers)
- Improved logs and added colors.
- Increased wait timeout for applying code changes. (This needs to be higher for larger docker images)
- Improved the error messages when update fails or when updates time out.