### PR TITLE
fix: return empty metrics data when no metric queries are built

### DIFF
--- a/aws/cloudwatch/metrics/getter.go
+++ b/aws/cloudwatch/metrics/getter.go
@@ -37,6 +37,11 @@ type Getter struct {
 func (g Getter) GetMetrics(ctx context.Context, options workspace.MetricsGetterOptions) (*workspace.MetricsData, error) {
 	periodSec := nsaws.CalcPeriod(options.StartTime, options.EndTime)
 	queries := g.Infra.MetricsMappings.BuildMetricQueries(options.Metrics, periodSec)
+	if len(queries) == 0 {
+		// CloudWatch rejects a GetMetricData request with no queries
+		// A workspace with no metrics mappings (or a filter matching none) has no metrics to fetch
+		return workspace.NewMetricsData(), nil
+	}
 	input := &cloudwatch.GetMetricDataInput{
 		StartTime:         options.StartTime,
 		EndTime:           options.EndTime,

--- a/aws/cloudwatch/metrics/getter_test.go
+++ b/aws/cloudwatch/metrics/getter_test.go
@@ -1,0 +1,56 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/nullstone-io/deployment-sdk/workspace"
+)
+
+func TestGetter_GetMetrics_NoQueries(t *testing.T) {
+	tests := []struct {
+		name    string
+		infra   Outputs
+		options workspace.MetricsGetterOptions
+	}{
+		{
+			name:    "empty metrics mappings",
+			infra:   Outputs{MetricsMappings: MappingGroups{}},
+			options: workspace.MetricsGetterOptions{},
+		},
+		{
+			name: "filter matches no mappings",
+			infra: Outputs{
+				MetricsMappings: MappingGroups{
+					{
+						Name: "cpu",
+						Type: "usage-percent",
+						Unit: "%",
+						Mappings: map[string]MetricMapping{
+							"cpu_average": {
+								Stat:       "Average",
+								Namespace:  "AWS/RDS",
+								MetricName: "CPUUtilization",
+							},
+						},
+					},
+				},
+			},
+			options: workspace.MetricsGetterOptions{Metrics: []string{"memory"}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			getter := Getter{Infra: test.infra}
+			got, err := getter.GetMetrics(context.Background(), test.options)
+			if err != nil {
+				t.Fatalf("GetMetrics() unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(workspace.NewMetricsData(), got); diff != "" {
+				t.Errorf("GetMetrics() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

CloudWatch `GetMetricData` rejects a request with an empty `MetricDataQueries`:

```
400 ValidationError: The parameter MetricDataQueries is required.
```

For workspaces with no metrics mappings (e.g. `aws/aws-fargate-task`, whose `base_metrics` is empty), `Getter.GetMetrics` built zero queries and sent the request anyway, surfacing in the Nullstone UI Monitoring tab as:

> unable to retrieve metrics: error retrieving metrics data: ...

## Fix

After building queries, if the slice is empty, return `workspace.NewMetricsData(), nil` without calling CloudWatch — the UI renders an empty/no-metrics state instead of an error.

The guard is on the built `queries` rather than `len(g.Infra.MetricsMappings)` because `options.Metrics` acts as a filter inside `BuildMetricQueries`, so non-empty mappings can still produce zero queries.

The GCP getter (`gcp/cloudmonitoring`) iterates mappings per-series and is naturally safe when empty — no change needed there.

## Testing

New `TestGetter_GetMetrics_NoQueries` covers both empty mappings and a filter matching nothing; both assert empty metrics data and nil error with no AWS call. `go test ./aws/cloudwatch/metrics/` passes (run with `-mod=mod` — the vendor tree is out of sync with go.mod on master, unrelated to this change).